### PR TITLE
Migrate QuTLASS kernels to torch Stable ABI

### DIFF
--- a/qutlass/csrc/bindings.cpp
+++ b/qutlass/csrc/bindings.cpp
@@ -22,6 +22,7 @@
 #include "include/bindings_utils.h"
 #include "include/gemm.h"
 #include "include/fused_quantize_host.h"
+#include "include/backward_host.h"
 
 namespace QUTLASS {
 
@@ -134,6 +135,84 @@ Tensor matmul_ada_mxf4_bf16_tn(Tensor const& A,
     matmul_host_ada_mxf4_bf16_tn(A, B, A_sf, B_sf, C, alpha);
 
     return C;
+}
+
+Tensor matmul_mxf8_bf16_tn(Tensor const& A,
+                          Tensor const& B,
+                          Tensor const& A_sf,
+                          Tensor const& B_sf,
+                          Tensor const& alpha)
+{
+    check_all_contiguous("matmul_mxf8_bf16_tn", {{A, "A", 0},
+                                                 {B, "B", 1},
+                                                 {A_sf, "A_sf", 2},
+                                                 {B_sf, "B_sf", 3},
+                                                 {alpha, "alpha", 4}});
+    check_device_type_cuda("matmul_mxf8_bf16_tn", {A, B, A_sf, B_sf, alpha});
+    check_all_same_gpu("matmul_mxf8_bf16_tn", {{A, "A", 0},
+                                              {B, "B", 1},
+                                              {A_sf, "A_sf", 2},
+                                              {B_sf, "B_sf", 3},
+                                              {alpha, "alpha", 4}});
+    STD_TORCH_CHECK(A.scalar_type() == ScalarType::Float8_e4m3fn,
+                    "A must be float8_e4m3fn");
+    STD_TORCH_CHECK(B.scalar_type() == ScalarType::Float8_e4m3fn,
+                    "B must be float8_e4m3fn");
+    STD_TORCH_CHECK(A_sf.scalar_type() == ScalarType::Float8_e8m0fnu,
+                    "A_sf must be float8_e8m0fnu");
+    STD_TORCH_CHECK(B_sf.scalar_type() == ScalarType::Float8_e8m0fnu,
+                    "B_sf must be float8_e8m0fnu");
+    STD_TORCH_CHECK(A.dim() == 2 && B.dim() == 2, "A and B must be 2D");
+    STD_TORCH_CHECK(A.size(1) == B.size(1), "Inner dimensions must match for A @ B.T");
+    STD_TORCH_CHECK(A.size(1) >= 32, "A K-dim must be >= 32");
+    STD_TORCH_CHECK(B.size(1) >= 32, "B K-dim must be >= 32");
+
+    uint32_t M = A.size(0);
+    uint32_t N = B.size(0);
+    auto OUT = torch::stable::new_empty(A, {M, N}, ScalarType::BFloat16);
+
+    matmul_host_mxf8_bf16_tn(OUT, A, B, A_sf, B_sf, alpha);
+
+    return OUT;
+}
+
+Tensor matmul_mxf8_bf16_nn(Tensor const& A,
+                          Tensor const& B,
+                          Tensor const& A_sf,
+                          Tensor const& B_sf,
+                          Tensor const& alpha)
+{
+    check_all_contiguous("matmul_mxf8_bf16_nn", {{A, "A", 0},
+                                                 {B, "B", 1},
+                                                 {A_sf, "A_sf", 2},
+                                                 {B_sf, "B_sf", 3},
+                                                 {alpha, "alpha", 4}});
+    check_device_type_cuda("matmul_mxf8_bf16_nn", {A, B, A_sf, B_sf, alpha});
+    check_all_same_gpu("matmul_mxf8_bf16_nn", {{A, "A", 0},
+                                              {B, "B", 1},
+                                              {A_sf, "A_sf", 2},
+                                              {B_sf, "B_sf", 3},
+                                              {alpha, "alpha", 4}});
+    STD_TORCH_CHECK(A.scalar_type() == ScalarType::Float8_e4m3fn,
+                    "A must be float8_e4m3fn");
+    STD_TORCH_CHECK(B.scalar_type() == ScalarType::Float8_e4m3fn,
+                    "B must be float8_e4m3fn");
+    STD_TORCH_CHECK(A_sf.scalar_type() == ScalarType::Float8_e8m0fnu,
+                    "A_sf must be float8_e8m0fnu");
+    STD_TORCH_CHECK(B_sf.scalar_type() == ScalarType::Float8_e8m0fnu,
+                    "B_sf must be float8_e8m0fnu");
+    STD_TORCH_CHECK(A.dim() == 2 && B.dim() == 2, "A and B must be 2D");
+    STD_TORCH_CHECK(A.size(0) == B.size(1), "Inner dimensions must match for A.T @ B.T");
+    STD_TORCH_CHECK(A.size(0) >= 32, "A K-dim must be >= 32");
+    STD_TORCH_CHECK(B.size(1) >= 32, "B K-dim must be >= 32");
+
+    uint32_t M = A.size(1);
+    uint32_t N = B.size(0);
+    auto OUT = torch::stable::new_empty(A, {M, N}, ScalarType::BFloat16);
+
+    matmul_host_mxf8_bf16_nn(OUT, A, B, A_sf, B_sf, alpha);
+
+    return OUT;
 }
 
 std::tuple<Tensor, Tensor> fusedQuantizeMxQuest(Tensor const& A,
@@ -344,26 +423,109 @@ std::tuple<Tensor, Tensor> fusedQuantizeNvAbsMax(Tensor const& A,
     return std::make_tuple(OUT, OUT_sf);
 }
 
+void backward_t_bf16(Tensor const& x,
+                     Tensor const& h,
+                     Tensor& xh_e2m1,
+                     Tensor& xh_e8m0)
+{
+    backward_t_bf16_cuda(
+        x.const_data_ptr(),
+        h.const_data_ptr(),
+        xh_e2m1.mutable_data_ptr(),
+        xh_e8m0.mutable_data_ptr(),
+        x.size(-1),
+        x.size(-2),
+        x.numel() / (x.size(-2) * x.size(-1)),
+        get_current_cuda_stream(h.get_device_index()));
+}
+
+void backward_qt_bf16(Tensor const& x_e2m1,
+                      Tensor const& x_e8m0,
+                      Tensor const& h,
+                      Tensor const& alpha,
+                      Tensor& xh_e2m1,
+                      Tensor& xh_e8m0)
+{
+    backward_qt_bf16_cuda(
+        x_e2m1.const_data_ptr(),
+        x_e8m0.const_data_ptr(),
+        h.const_data_ptr(),
+        alpha.const_data_ptr(),
+        xh_e2m1.mutable_data_ptr(),
+        xh_e8m0.mutable_data_ptr(),
+        x_e2m1.size(-1) * 2,
+        x_e2m1.size(-2),
+        x_e2m1.numel() / (x_e2m1.size(-2) * x_e2m1.size(-1)),
+        get_current_cuda_stream(h.get_device_index()));
+}
+
+void backward_bf16_square_double_mxfp8(Tensor const& x_bf16,
+                                       Tensor& x_fp8,
+                                       Tensor& row_scales,
+                                       Tensor& column_scales)
+{
+    backward_bf16_square_double_mxfp8_cuda(
+        x_bf16.const_data_ptr(),
+        x_bf16.size(0),
+        x_bf16.size(1),
+        x_fp8.mutable_data_ptr(),
+        row_scales.mutable_data_ptr(),
+        column_scales.mutable_data_ptr(),
+        get_current_cuda_stream(x_bf16.get_device_index()));
+}
+
+void mxfp4_transpose_mxfp8(Tensor const& x_fp4,
+                           Tensor const& scales,
+                           Tensor& x_fp8,
+                           Tensor& shared_exps)
+{
+    mxfp4_transpose_mxfp8_cuda(
+        x_fp4.const_data_ptr(),
+        scales.const_data_ptr(),
+        x_fp4.size(0),
+        x_fp4.size(1) * 2,
+        x_fp8.mutable_data_ptr(),
+        shared_exps.mutable_data_ptr(),
+        get_current_cuda_stream(x_fp4.get_device_index()));
+}
+
 }  // namespace QUTLASS
 
 STABLE_TORCH_LIBRARY_FRAGMENT(_qutlass_C, ops) {
   ops.def("matmul_mxf4_bf16_tn(Tensor A, Tensor B, Tensor A_sf, Tensor B_sf, Tensor alpha) -> Tensor");
   ops.def("matmul_nvf4_bf16_tn(Tensor A, Tensor B, Tensor A_sf, Tensor B_sf, Tensor alpha) -> Tensor");
   ops.def("matmul_ada_mxf4_bf16_tn(Tensor A, Tensor B, Tensor A_sf, Tensor B_sf, Tensor alpha) -> Tensor");
+  ops.def("matmul_mxf8_bf16_tn(Tensor A, Tensor B, Tensor A_sf, Tensor B_sf, Tensor alpha) -> Tensor");
+  ops.def("matmul_mxf8_bf16_nn(Tensor A, Tensor B, Tensor A_sf, Tensor B_sf, Tensor alpha) -> Tensor");
   ops.def("fusedQuantizeMxQuest(Tensor A, Tensor R, Tensor OUT, Tensor OUT_sf) -> (Tensor, Tensor)");
-  ops.def("fusedQuantizeMxQuestWithMask(Tensor A, Tensor R, Tensor OUT, Tensor OUT_sf, Tensor OUT_mask) -> (Tensor, Tensor, Tensor)");
   ops.def("fusedQuantizeMxAbsMax(Tensor A, Tensor R, Tensor OUT, Tensor OUT_sf) -> (Tensor, Tensor)");
   ops.def("fusedQuantizeNvQuest(Tensor A, Tensor R, Tensor OUT, Tensor OUT_sf, Tensor global_scale) -> (Tensor, Tensor)");
   ops.def("fusedQuantizeNvAbsMax(Tensor A, Tensor R, Tensor OUT, Tensor OUT_sf, Tensor global_scale) -> (Tensor, Tensor)");
+#ifndef QUTLASS_MINIMAL_BUILD
+  ops.def("fusedQuantizeMxQuestWithMask(Tensor A, Tensor R, Tensor OUT, Tensor OUT_sf, Tensor OUT_mask) -> (Tensor, Tensor, Tensor)");
+  ops.def("backward_t_bf16(Tensor x, Tensor h, Tensor xh_e2m1, Tensor xh_e8m0) -> ()");
+  ops.def("backward_qt_bf16(Tensor x_e2m1, Tensor x_e8m0, Tensor h, Tensor alpha, Tensor xh_e2m1, Tensor xh_e8m0) -> ()");
+  ops.def("backward_bf16_square_double_mxfp8(Tensor x_bf16, Tensor x_fp8, Tensor row_scales, Tensor column_scales) -> ()");
+  ops.def("mxfp4_transpose_mxfp8(Tensor x_fp4, Tensor scales, Tensor x_fp8, Tensor shared_exps) -> ()");
+#endif
 }
 
 STABLE_TORCH_LIBRARY_IMPL(_qutlass_C, CUDA, ops) {
   ops.impl("matmul_mxf4_bf16_tn", TORCH_BOX(&QUTLASS::matmul_mxf4_bf16_tn));
   ops.impl("matmul_nvf4_bf16_tn", TORCH_BOX(&QUTLASS::matmul_nvf4_bf16_tn));
   ops.impl("matmul_ada_mxf4_bf16_tn", TORCH_BOX(&QUTLASS::matmul_ada_mxf4_bf16_tn));
+  ops.impl("matmul_mxf8_bf16_tn", TORCH_BOX(&QUTLASS::matmul_mxf8_bf16_tn));
+  ops.impl("matmul_mxf8_bf16_nn", TORCH_BOX(&QUTLASS::matmul_mxf8_bf16_nn));
   ops.impl("fusedQuantizeMxQuest", TORCH_BOX(&QUTLASS::fusedQuantizeMxQuest));
-  ops.impl("fusedQuantizeMxQuestWithMask", TORCH_BOX(&QUTLASS::fusedQuantizeMxQuestWithMask));
   ops.impl("fusedQuantizeMxAbsMax", TORCH_BOX(&QUTLASS::fusedQuantizeMxAbsMax));
   ops.impl("fusedQuantizeNvQuest", TORCH_BOX(&QUTLASS::fusedQuantizeNvQuest));
   ops.impl("fusedQuantizeNvAbsMax", TORCH_BOX(&QUTLASS::fusedQuantizeNvAbsMax));
+#ifndef QUTLASS_MINIMAL_BUILD
+  ops.impl("fusedQuantizeMxQuestWithMask", TORCH_BOX(&QUTLASS::fusedQuantizeMxQuestWithMask));
+  ops.impl("backward_t_bf16", TORCH_BOX(&QUTLASS::backward_t_bf16));
+  ops.impl("backward_qt_bf16", TORCH_BOX(&QUTLASS::backward_qt_bf16));
+  ops.impl("backward_bf16_square_double_mxfp8",
+           TORCH_BOX(&QUTLASS::backward_bf16_square_double_mxfp8));
+  ops.impl("mxfp4_transpose_mxfp8", TORCH_BOX(&QUTLASS::mxfp4_transpose_mxfp8));
+#endif
 }

--- a/qutlass/csrc/bindings.cpp
+++ b/qutlass/csrc/bindings.cpp
@@ -17,147 +17,16 @@
 #include <torch/csrc/stable/library.h>
 #include <torch/headeronly/core/ScalarType.h>
 
-#include <initializer_list>
-#include <sstream>
 #include <utility>
 
+#include "include/bindings_utils.h"
 #include "include/gemm.h"
 #include "include/fused_quantize_host.h"
 
-namespace {
+namespace QUTLASS {
 
 using torch::stable::Tensor;
-using torch::headeronly::DeviceType;
 using torch::headeronly::ScalarType;
-
-struct TensorArg {
-  const Tensor& tensor;
-  const char* name;
-  int pos;
-};
-
-inline std::ostream& operator<<(std::ostream& out, const TensorArg& t) {
-  if (t.pos == 0) {
-    out << '\'' << t.name << '\'';
-  } else {
-    out << "argument #" << t.pos << " '" << t.name << '\'';
-  }
-  return out;
-}
-
-inline const char* device_type_name(DeviceType type) {
-  switch (type) {
-    case DeviceType::CPU:
-      return "cpu";
-    case DeviceType::CUDA:
-      return "cuda";
-    case DeviceType::HIP:
-      return "hip";
-    case DeviceType::XLA:
-      return "xla";
-    case DeviceType::MPS:
-      return "mps";
-    case DeviceType::XPU:
-      return "xpu";
-    case DeviceType::Meta:
-      return "meta";
-    case DeviceType::PrivateUse1:
-      return "privateuseone";
-    default:
-      return "unknown";
-  }
-}
-
-inline void append_device_type_string(std::ostream& out, DeviceType type) {
-  out << device_type_name(type);
-}
-
-inline void append_device_string(std::ostream& out, const Tensor& t) {
-  const auto device = t.device();
-  append_device_type_string(out, device.type());
-  if (device.has_index()) {
-    out << ':' << device.index();
-  }
-}
-
-inline void check_contiguous(const char* op, const TensorArg& t) {
-  if (t.tensor.is_contiguous()) {
-    return;
-  }
-  std::ostringstream oss;
-  oss << "Expected contiguous tensor, but got non-contiguous tensor for " << t
-      << " (while checking arguments for " << op << ")";
-  STD_TORCH_CHECK(false, oss.str());
-}
-
-inline void check_all_contiguous(const char* op,
-                                 std::initializer_list<TensorArg> args) {
-  for (const auto& arg : args) {
-    check_contiguous(op, arg);
-  }
-}
-
-inline void check_device_type_cuda(const char* op,
-                                   std::initializer_list<Tensor> tensors) {
-  for (const auto& tensor : tensors) {
-    if (tensor.device().is_cuda()) {
-      continue;
-    }
-    std::ostringstream oss;
-    oss << "Expected tensor to have cuda DeviceType, but got tensor with "
-        << device_type_name(tensor.device().type())
-        << " DeviceType (while checking arguments for " << op << ")";
-    STD_TORCH_CHECK(false, oss.str());
-  }
-}
-
-inline void check_same_gpu(const char* op,
-                           const TensorArg& t1,
-                           const TensorArg& t2) {
-  const bool t1_cuda = t1.tensor.device().is_cuda();
-  const bool t2_cuda = t2.tensor.device().is_cuda();
-  if (!t1_cuda || !t2_cuda) {
-    std::ostringstream oss;
-    if (!t1_cuda) {
-      oss << "Tensor for " << t1 << " is on CPU, ";
-    }
-    if (!t2_cuda) {
-      oss << "Tensor for " << t2 << " is on CPU, ";
-    }
-    oss << "but expected " << ((t1_cuda && t2_cuda) ? "them" : "it")
-        << " to be on GPU (while checking arguments for " << op << ')';
-    STD_TORCH_CHECK(false, oss.str());
-  }
-  const int d1 = t1.tensor.get_device_index();
-  const int d2 = t2.tensor.get_device_index();
-  if (d1 == d2) {
-    return;
-  }
-  std::ostringstream oss;
-  oss << "Expected tensor for " << t1 << " to have the same device as tensor for "
-      << t2 << "; but device ";
-  append_device_string(oss, t1.tensor);
-  oss << " does not equal ";
-  append_device_string(oss, t2.tensor);
-  oss << " (while checking arguments for " << op << ")";
-  STD_TORCH_CHECK(false, oss.str());
-}
-
-inline void check_all_same_gpu(const char* op,
-                               std::initializer_list<TensorArg> args) {
-  const TensorArg* first = nullptr;
-  for (const auto& arg : args) {
-    if (first == nullptr) {
-      first = &arg;
-    } else {
-      check_same_gpu(op, *first, arg);
-    }
-  }
-}
-
-}  // namespace
-
-namespace QUTLASS {
 
 Tensor matmul_mxf4_bf16_tn(Tensor const& A,
                           Tensor const& B,

--- a/qutlass/csrc/bindings.cpp
+++ b/qutlass/csrc/bindings.cpp
@@ -14,527 +14,486 @@
  * limitations under the License.
  */
 
-#include <ATen/ATen.h>
-#include <torch/types.h>
-#include <ATen/cuda/CUDAContext.h>
-#include <c10/cuda/CUDAGuard.h>
-#include <cuda_runtime.h>
+#include <torch/csrc/stable/library.h>
+#include <torch/headeronly/core/ScalarType.h>
 
-#ifndef QUTLASS_DISABLE_PYBIND
-#include <torch/extension.h>
-#endif
-
-#include <vector>
-#include <iostream>
+#include <initializer_list>
+#include <sstream>
 #include <utility>
 
 #include "include/gemm.h"
 #include "include/fused_quantize_host.h"
-#include "include/backward_host.h"
+
+namespace {
+
+using torch::stable::Tensor;
+using torch::headeronly::DeviceType;
+using torch::headeronly::ScalarType;
+
+struct TensorArg {
+  const Tensor& tensor;
+  const char* name;
+  int pos;
+};
+
+inline std::ostream& operator<<(std::ostream& out, const TensorArg& t) {
+  if (t.pos == 0) {
+    out << '\'' << t.name << '\'';
+  } else {
+    out << "argument #" << t.pos << " '" << t.name << '\'';
+  }
+  return out;
+}
+
+inline const char* device_type_name(DeviceType type) {
+  switch (type) {
+    case DeviceType::CPU:
+      return "cpu";
+    case DeviceType::CUDA:
+      return "cuda";
+    case DeviceType::HIP:
+      return "hip";
+    case DeviceType::XLA:
+      return "xla";
+    case DeviceType::MPS:
+      return "mps";
+    case DeviceType::XPU:
+      return "xpu";
+    case DeviceType::Meta:
+      return "meta";
+    case DeviceType::PrivateUse1:
+      return "privateuseone";
+    default:
+      return "unknown";
+  }
+}
+
+inline void append_device_type_string(std::ostream& out, DeviceType type) {
+  out << device_type_name(type);
+}
+
+inline void append_device_string(std::ostream& out, const Tensor& t) {
+  const auto device = t.device();
+  append_device_type_string(out, device.type());
+  if (device.has_index()) {
+    out << ':' << device.index();
+  }
+}
+
+inline void check_contiguous(const char* op, const TensorArg& t) {
+  if (t.tensor.is_contiguous()) {
+    return;
+  }
+  std::ostringstream oss;
+  oss << "Expected contiguous tensor, but got non-contiguous tensor for " << t
+      << " (while checking arguments for " << op << ")";
+  STD_TORCH_CHECK(false, oss.str());
+}
+
+inline void check_all_contiguous(const char* op,
+                                 std::initializer_list<TensorArg> args) {
+  for (const auto& arg : args) {
+    check_contiguous(op, arg);
+  }
+}
+
+inline void check_device_type_cuda(const char* op,
+                                   std::initializer_list<Tensor> tensors) {
+  for (const auto& tensor : tensors) {
+    if (tensor.device().is_cuda()) {
+      continue;
+    }
+    std::ostringstream oss;
+    oss << "Expected tensor to have cuda DeviceType, but got tensor with "
+        << device_type_name(tensor.device().type())
+        << " DeviceType (while checking arguments for " << op << ")";
+    STD_TORCH_CHECK(false, oss.str());
+  }
+}
+
+inline void check_same_gpu(const char* op,
+                           const TensorArg& t1,
+                           const TensorArg& t2) {
+  const bool t1_cuda = t1.tensor.device().is_cuda();
+  const bool t2_cuda = t2.tensor.device().is_cuda();
+  if (!t1_cuda || !t2_cuda) {
+    std::ostringstream oss;
+    if (!t1_cuda) {
+      oss << "Tensor for " << t1 << " is on CPU, ";
+    }
+    if (!t2_cuda) {
+      oss << "Tensor for " << t2 << " is on CPU, ";
+    }
+    oss << "but expected " << ((t1_cuda && t2_cuda) ? "them" : "it")
+        << " to be on GPU (while checking arguments for " << op << ')';
+    STD_TORCH_CHECK(false, oss.str());
+  }
+  const int d1 = t1.tensor.get_device_index();
+  const int d2 = t2.tensor.get_device_index();
+  if (d1 == d2) {
+    return;
+  }
+  std::ostringstream oss;
+  oss << "Expected tensor for " << t1 << " to have the same device as tensor for "
+      << t2 << "; but device ";
+  append_device_string(oss, t1.tensor);
+  oss << " does not equal ";
+  append_device_string(oss, t2.tensor);
+  oss << " (while checking arguments for " << op << ")";
+  STD_TORCH_CHECK(false, oss.str());
+}
+
+inline void check_all_same_gpu(const char* op,
+                               std::initializer_list<TensorArg> args) {
+  const TensorArg* first = nullptr;
+  for (const auto& arg : args) {
+    if (first == nullptr) {
+      first = &arg;
+    } else {
+      check_same_gpu(op, *first, arg);
+    }
+  }
+}
+
+}  // namespace
 
 namespace QUTLASS {
 
-torch::Tensor matmul_mxf4_bf16_tn(torch::Tensor const& A,
-                                  torch::Tensor const& B,
-                                  torch::Tensor const& A_sf,
-                                  torch::Tensor const& B_sf,
-                                  torch::Tensor const& alpha)
+Tensor matmul_mxf4_bf16_tn(Tensor const& A,
+                          Tensor const& B,
+                          Tensor const& A_sf,
+                          Tensor const& B_sf,
+                          Tensor const& alpha)
 {
-    torch::checkAllContiguous("matmul_mxf4_bf16_tn", {{A, "A", 0},
-                                                      {B, "B", 1},
-                                                      {A_sf, "A_sf", 2},
-                                                      {B_sf, "B_sf", 3}});
-    torch::checkDeviceType("matmul_mxf4_bf16_tn", {A, B, A_sf, B_sf, alpha}, at::DeviceType::CUDA);
-    torch::checkAllSameGPU("matmul_mxf4_bf16_tn", {{A, "A", 0},
-                                                   {B, "B", 1},
-                                                   {A_sf, "A_sf", 2},
-                                                   {B_sf, "B_sf", 3},
-                                                   {alpha, "alpha", 4}});
-    TORCH_CHECK(A.scalar_type() == at::kByte, "A must be uint8");
-    TORCH_CHECK(B.scalar_type() == at::kByte, "B must be uint8");
-    TORCH_CHECK(A_sf.scalar_type() == at::kFloat8_e8m0fnu, "A_sf must be float8_e8m0fnu");
-    TORCH_CHECK(B_sf.scalar_type() == at::kFloat8_e8m0fnu, "B_sf must be float8_e8m0fnu");
-    TORCH_CHECK(A.dim() == 2 && B.dim() == 2, "A and B must be 2D");
-    TORCH_CHECK(A.size(1) == B.size(1), "Inner dimensions must match for A @ B.T");
-    TORCH_CHECK(A.size(1) >= 32, "A K-dim must be >= 32");
-    TORCH_CHECK(B.size(1) >= 32, "B K-dim must be >= 32");
+    check_all_contiguous("matmul_mxf4_bf16_tn", {{A, "A", 0},
+                                                 {B, "B", 1},
+                                                 {A_sf, "A_sf", 2},
+                                                 {B_sf, "B_sf", 3}});
+    check_device_type_cuda("matmul_mxf4_bf16_tn", {A, B, A_sf, B_sf, alpha});
+    check_all_same_gpu("matmul_mxf4_bf16_tn", {{A, "A", 0},
+                                              {B, "B", 1},
+                                              {A_sf, "A_sf", 2},
+                                              {B_sf, "B_sf", 3},
+                                              {alpha, "alpha", 4}});
+    STD_TORCH_CHECK(A.scalar_type() == ScalarType::Byte, "A must be uint8");
+    STD_TORCH_CHECK(B.scalar_type() == ScalarType::Byte, "B must be uint8");
+    STD_TORCH_CHECK(A_sf.scalar_type() == ScalarType::Float8_e8m0fnu,
+                    "A_sf must be float8_e8m0fnu");
+    STD_TORCH_CHECK(B_sf.scalar_type() == ScalarType::Float8_e8m0fnu,
+                    "B_sf must be float8_e8m0fnu");
+    STD_TORCH_CHECK(A.dim() == 2 && B.dim() == 2, "A and B must be 2D");
+    STD_TORCH_CHECK(A.size(1) == B.size(1), "Inner dimensions must match for A @ B.T");
+    STD_TORCH_CHECK(A.size(1) >= 32, "A K-dim must be >= 32");
+    STD_TORCH_CHECK(B.size(1) >= 32, "B K-dim must be >= 32");
 
     uint32_t M = A.size(0);
     uint32_t N = B.size(0);
-    auto OUT   = torch::empty({M, N}, torch::dtype(torch::kBFloat16).device(A.device()));
+    auto OUT = torch::stable::new_empty(A, {M, N}, ScalarType::BFloat16);
 
     matmul_host_mxf4_bf16_tn(OUT, A, B, A_sf, B_sf, alpha);
 
     return OUT;
 }
 
-torch::Tensor matmul_nvf4_bf16_tn(torch::Tensor const& A,
-                                  torch::Tensor const& B,
-                                  torch::Tensor const& A_sf,
-                                  torch::Tensor const& B_sf,
-                                  torch::Tensor const& alpha)
+Tensor matmul_nvf4_bf16_tn(Tensor const& A,
+                           Tensor const& B,
+                           Tensor const& A_sf,
+                           Tensor const& B_sf,
+                           Tensor const& alpha)
 {
-    torch::checkAllContiguous("matmul_nvf4_bf16_tn", {{A, "A", 0},
-                                                      {B, "B", 1},
-                                                      {A_sf, "A_sf", 2},
-                                                      {B_sf, "B_sf", 3}});
-    torch::checkDeviceType("matmul_nvf4_bf16_tn", {A, B, A_sf, B_sf, alpha}, at::DeviceType::CUDA);
-    torch::checkAllSameGPU("matmul_nvf4_bf16_tn", {{A, "A", 0},
-                                                   {B, "B", 1},
-                                                   {A_sf, "A_sf", 2},
-                                                   {B_sf, "B_sf", 3},
-                                                   {alpha, "alpha", 4}});
-    TORCH_CHECK(A.scalar_type() == at::kByte, "A must be uint8");
-    TORCH_CHECK(B.scalar_type() == at::kByte, "B must be uint8");
-    TORCH_CHECK(A_sf.scalar_type() == at::kFloat8_e4m3fn, "A_sf must be float8_e4m3fn");
-    TORCH_CHECK(B_sf.scalar_type() == at::kFloat8_e4m3fn, "B_sf must be float8_e4m3fn");
-    TORCH_CHECK(A.dim() == 2 && B.dim() == 2, "A and B must be 2D");
-    TORCH_CHECK(A.size(1) == B.size(1), "Inner dimensions must match for A @ B.T");
-    TORCH_CHECK(A.size(1) >= 16, "A K-dim must be >= 16");
-    TORCH_CHECK(B.size(1) >= 16, "B K-dim must be >= 16");
+    check_all_contiguous("matmul_nvf4_bf16_tn", {{A, "A", 0},
+                                                 {B, "B", 1},
+                                                 {A_sf, "A_sf", 2},
+                                                 {B_sf, "B_sf", 3}});
+    check_device_type_cuda("matmul_nvf4_bf16_tn", {A, B, A_sf, B_sf, alpha});
+    check_all_same_gpu("matmul_nvf4_bf16_tn", {{A, "A", 0},
+                                              {B, "B", 1},
+                                              {A_sf, "A_sf", 2},
+                                              {B_sf, "B_sf", 3},
+                                              {alpha, "alpha", 4}});
+    STD_TORCH_CHECK(A.scalar_type() == ScalarType::Byte, "A must be uint8");
+    STD_TORCH_CHECK(B.scalar_type() == ScalarType::Byte, "B must be uint8");
+    STD_TORCH_CHECK(A_sf.scalar_type() == ScalarType::Float8_e4m3fn,
+                    "A_sf must be float8_e4m3fn");
+    STD_TORCH_CHECK(B_sf.scalar_type() == ScalarType::Float8_e4m3fn,
+                    "B_sf must be float8_e4m3fn");
+    STD_TORCH_CHECK(A.dim() == 2 && B.dim() == 2, "A and B must be 2D");
+    STD_TORCH_CHECK(A.size(1) == B.size(1), "Inner dimensions must match for A @ B.T");
+    STD_TORCH_CHECK(A.size(1) >= 16, "A K-dim must be >= 16");
+    STD_TORCH_CHECK(B.size(1) >= 16, "B K-dim must be >= 16");
 
     uint32_t M = A.size(0);
     uint32_t N = B.size(0);
-    auto OUT   = torch::empty({M, N}, torch::dtype(torch::kBFloat16).device(A.device()));
+    auto OUT = torch::stable::new_empty(A, {M, N}, ScalarType::BFloat16);
 
     matmul_host_nvf4_bf16_tn(OUT, A, B, A_sf, B_sf, alpha);
 
     return OUT;
 }
 
-torch::Tensor matmul_ada_mxf4_bf16_tn(torch::Tensor const&A,
-                                      torch::Tensor const&B,
-                                      torch::Tensor const&A_sf,
-                                      torch::Tensor const&B_sf,
-                                      torch::Tensor const& alpha)
+Tensor matmul_ada_mxf4_bf16_tn(Tensor const& A,
+                               Tensor const& B,
+                               Tensor const& A_sf,
+                               Tensor const& B_sf,
+                               Tensor const& alpha)
 {
-    torch::checkAllContiguous("matmul_ada_mxf4_bf16_tn", {{A, "A", 0},
-                                                      {B, "B", 1},
-                                                      {A_sf, "A_sf", 2},
-                                                      {B_sf, "B_sf", 3}});
-    torch::checkDeviceType("matmul_ada_mxf4_bf16_tn", {A, B, A_sf, B_sf, alpha}, at::DeviceType::CUDA);
-    torch::checkAllSameGPU("matmul_ada_mxf4_bf16_tn", {{A, "A", 0},
-                                                       {B, "B", 1},
-                                                       {A_sf, "A_sf", 2},
-                                                       {B_sf, "B_sf", 3},
-                                                       {alpha, "alpha", 4}});
-    TORCH_CHECK(A.scalar_type() == at::kByte, "A must be uint8");
-    TORCH_CHECK(B.scalar_type() == at::kByte, "B must be uint8");
-    TORCH_CHECK(A_sf.scalar_type() == at::kFloat8_e8m0fnu, "A_sf must be float8_e8m0fnu");
-    TORCH_CHECK(B_sf.scalar_type() == at::kFloat8_e8m0fnu, "B_sf must be float8_e8m0fnu");
-    TORCH_CHECK(A.dim() == 2 && B.dim() == 2, "A and B must be 2D");
-    TORCH_CHECK(A.size(1) == B.size(1), "Inner dimensions must match for A @ B.T");
-    TORCH_CHECK(A.size(1) >= 32, "A K-dim must be >= 32");
-    TORCH_CHECK(B.size(1) >= 32, "B K-dim must be >= 32");
+    check_all_contiguous("matmul_ada_mxf4_bf16_tn", {{A, "A", 0},
+                                                     {B, "B", 1},
+                                                     {A_sf, "A_sf", 2},
+                                                     {B_sf, "B_sf", 3}});
+    check_device_type_cuda("matmul_ada_mxf4_bf16_tn", {A, B, A_sf, B_sf, alpha});
+    check_all_same_gpu("matmul_ada_mxf4_bf16_tn", {{A, "A", 0},
+                                                   {B, "B", 1},
+                                                   {A_sf, "A_sf", 2},
+                                                   {B_sf, "B_sf", 3},
+                                                   {alpha, "alpha", 4}});
+    STD_TORCH_CHECK(A.scalar_type() == ScalarType::Byte, "A must be uint8");
+    STD_TORCH_CHECK(B.scalar_type() == ScalarType::Byte, "B must be uint8");
+    STD_TORCH_CHECK(A_sf.scalar_type() == ScalarType::Float8_e8m0fnu,
+                    "A_sf must be float8_e8m0fnu");
+    STD_TORCH_CHECK(B_sf.scalar_type() == ScalarType::Float8_e8m0fnu,
+                    "B_sf must be float8_e8m0fnu");
+    STD_TORCH_CHECK(A.dim() == 2 && B.dim() == 2, "A and B must be 2D");
+    STD_TORCH_CHECK(A.size(1) == B.size(1), "Inner dimensions must match for A @ B.T");
+    STD_TORCH_CHECK(A.size(1) >= 32, "A K-dim must be >= 32");
+    STD_TORCH_CHECK(B.size(1) >= 32, "B K-dim must be >= 32");
 
     uint32_t M = A.size(0);
     uint32_t N = B.size(0);
-    auto C = torch::empty({M, N}, torch::dtype(torch::kBFloat16).device(A.device()));
+    auto C = torch::stable::new_empty(A, {M, N}, ScalarType::BFloat16);
 
     matmul_host_ada_mxf4_bf16_tn(A, B, A_sf, B_sf, C, alpha);
 
     return C;
 }
 
-torch::Tensor matmul_mxf8_bf16_tn(torch::Tensor const& A,
-                                  torch::Tensor const& B,
-                                  torch::Tensor const& A_sf,
-                                  torch::Tensor const& B_sf,
-                                  torch::Tensor const& alpha)
+std::tuple<Tensor, Tensor> fusedQuantizeMxQuest(Tensor const& A,
+                                                Tensor const& B,
+                                                Tensor& OUT,
+                                                Tensor& OUT_sf)
 {
-    torch::checkAllContiguous("matmul_mxf8_bf16_tn", {{A, "A", 0},
-                                                      {B, "B", 1},
-                                                      {A_sf, "A_sf", 2},
-                                                      {B_sf, "B_sf", 3},
-                                                      {alpha, "alpha", 4}});
-    torch::checkDeviceType("matmul_mxf8_bf16_tn", {A, B, A_sf, B_sf, alpha}, at::DeviceType::CUDA);
-
-    torch::checkAllSameGPU("matmul_mxf8_bf16_tn", {{A, "A", 0},
-                                                   {B, "B", 1},
-                                                   {A_sf, "A_sf", 2},
-                                                   {B_sf, "B_sf", 3},
-                                                   {alpha, "alpha", 4}});
-
-    TORCH_CHECK(A.scalar_type() == at::kFloat8_e4m3fn, "A must be float8_e4m3fn");
-    TORCH_CHECK(B.scalar_type() == at::kFloat8_e4m3fn, "B must be float8_e4m3fn");
-    TORCH_CHECK(A_sf.scalar_type() == at::kFloat8_e8m0fnu, "A_sf must be float8_e8m0fnu");
-    TORCH_CHECK(B_sf.scalar_type() == at::kFloat8_e8m0fnu, "B_sf must be float8_e8m0fnu");
-    TORCH_CHECK(A.dim() == 2 && B.dim() == 2, "A and B must be 2D");
-    TORCH_CHECK(A.size(1) == B.size(1), "Inner dimensions must match for A @ B.T");
-    TORCH_CHECK(A.size(1) >= 32, "A K-dim must be >= 32");
-    TORCH_CHECK(B.size(1) >= 32, "B K-dim must be >= 32");
-
-    uint32_t M = A.size(0);
-    uint32_t N = B.size(0);
-    auto OUT = torch::empty({M, N}, torch::dtype(torch::kBFloat16).device(A.device()));
-
-    matmul_host_mxf8_bf16_tn(OUT, A, B, A_sf, B_sf, alpha);
-
-    return OUT;
-}
-
-torch::Tensor matmul_mxf8_bf16_nn(torch::Tensor const& A,
-                                  torch::Tensor const& B,
-                                  torch::Tensor const& A_sf,
-                                  torch::Tensor const& B_sf,
-                                  torch::Tensor const& alpha)
-{
-    torch::checkAllContiguous("matmul_mxf8_bf16_nn", {{A, "A", 0},
-                                                      {B, "B", 1},
-                                                      {A_sf, "A_sf", 2},
-                                                      {B_sf, "B_sf", 3},
-                                                      {alpha, "alpha", 4}});
-    torch::checkDeviceType("matmul_mxf8_bf16_nn", {A, B, A_sf, B_sf, alpha}, at::DeviceType::CUDA);
-
-    torch::checkAllSameGPU("matmul_mxf8_bf16_nn", {{A, "A", 0},
-                                                   {B, "B", 1},
-                                                   {A_sf, "A_sf", 2},
-                                                   {B_sf, "B_sf", 3},
-                                                   {alpha, "alpha", 4}});
-
-    TORCH_CHECK(A.scalar_type() == at::kFloat8_e4m3fn, "A must be float8_e4m3fn");
-    TORCH_CHECK(B.scalar_type() == at::kFloat8_e4m3fn, "B must be float8_e4m3fn");
-    TORCH_CHECK(A_sf.scalar_type() == at::kFloat8_e8m0fnu, "A_sf must be float8_e8m0fnu");
-    TORCH_CHECK(B_sf.scalar_type() == at::kFloat8_e8m0fnu, "B_sf must be float8_e8m0fnu");
-    TORCH_CHECK(A.dim() == 2 && B.dim() == 2, "A and B must be 2D");
-    TORCH_CHECK(A.size(0) == B.size(1), "Inner dimensions must match for A.T @ B.T");
-    TORCH_CHECK(A.size(0) >= 32, "A K-dim must be >= 32");
-    TORCH_CHECK(B.size(1) >= 32, "B K-dim must be >= 32");
-
-    uint32_t M = A.size(1);
-    uint32_t N = B.size(0);
-    auto OUT = torch::empty({M, N}, torch::dtype(torch::kBFloat16).device(A.device()));
-
-    matmul_host_mxf8_bf16_nn(OUT, A, B, A_sf, B_sf, alpha);
-
-    return OUT;
-}
-
-std::tuple<torch::Tensor, torch::Tensor> fusedQuantizeMxQuest(torch::Tensor const& A,
-                                                              torch::Tensor const& B,
-                                                              torch::Tensor& OUT,
-                                                              torch::Tensor& OUT_sf)
-{
-    torch::checkAllContiguous("fusedQuantizeMxQuest", {{A, "A", 0},
-                                                       {B, "B", 1},
-                                                       {OUT, "OUT", 2},
-                                                       {OUT_sf, "OUT_sf", 3}});
-    torch::checkDeviceType("fusedQuantizeMxQuest", {A, B, OUT, OUT_sf}, at::DeviceType::CUDA);
-    torch::checkAllSameGPU("fusedQuantizeMxQuest", {{A, "A", 0},
-                                                    {B, "B", 1},
-                                                    {OUT, "OUT", 2},
-                                                    {OUT_sf, "OUT_sf", 3}});
-    TORCH_CHECK(A.scalar_type() == at::kBFloat16, "A must be bf16");
-    TORCH_CHECK(B.scalar_type() == at::kBFloat16, "B must be bf16");
-    TORCH_CHECK(B.size(0) == B.size(1), "Rotation matrix must be square");
+    check_all_contiguous("fusedQuantizeMxQuest", {{A, "A", 0},
+                                                  {B, "B", 1},
+                                                  {OUT, "OUT", 2},
+                                                  {OUT_sf, "OUT_sf", 3}});
+    check_device_type_cuda("fusedQuantizeMxQuest", {A, B, OUT, OUT_sf});
+    check_all_same_gpu("fusedQuantizeMxQuest", {{A, "A", 0},
+                                              {B, "B", 1},
+                                              {OUT, "OUT", 2},
+                                              {OUT_sf, "OUT_sf", 3}});
+    STD_TORCH_CHECK(A.scalar_type() == ScalarType::BFloat16, "A must be bf16");
+    STD_TORCH_CHECK(B.scalar_type() == ScalarType::BFloat16, "B must be bf16");
+    STD_TORCH_CHECK(B.size(0) == B.size(1), "Rotation matrix must be square");
 
     uint32_t HAD_GS = B.size(0);
-    TORCH_CHECK((A.numel()%HAD_GS)==0, "A must be divisible by", HAD_GS);
+    STD_TORCH_CHECK((A.numel() % HAD_GS) == 0, "A must be divisible by", HAD_GS);
 
-    if(HAD_GS==32){
+    if (HAD_GS == 32) {
         fusedQuantizeMxQuest_host(OUT, OUT_sf, A, B);
-    } else if(HAD_GS==64){
+    } else if (HAD_GS == 64) {
         fusedQuantizeMxQuestHad64_host(OUT, OUT_sf, A, B);
-    } else if(HAD_GS==128){
+    } else if (HAD_GS == 128) {
         fusedQuantizeMxQuestHad128_host(OUT, OUT_sf, A, B);
     } else {
-        TORCH_CHECK(false,
-                    "Unsupported rotation size ", HAD_GS,
-                    "; expected 32, 64, or 128.");
+        STD_TORCH_CHECK(false,
+                        "Unsupported rotation size ", HAD_GS,
+                        "; expected 32, 64, or 128.");
     }
 
     return std::make_tuple(OUT, OUT_sf);
 }
 
-std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> fusedQuantizeMxQuestWithMask(
-                                                                    torch::Tensor const& A,
-                                                                    torch::Tensor const& B,
-                                                                    torch::Tensor& OUT,
-                                                                    torch::Tensor& OUT_sf,
-                                                                    torch::Tensor& OUT_mask)
+std::tuple<Tensor, Tensor, Tensor> fusedQuantizeMxQuestWithMask(
+    Tensor const& A,
+    Tensor const& B,
+    Tensor& OUT,
+    Tensor& OUT_sf,
+    Tensor& OUT_mask)
 {
-    torch::checkAllContiguous("fusedQuantizeMxQuestWithMask", {{A, "A", 0},
-                                                               {B, "B", 1},
-                                                               {OUT, "OUT", 2},
-                                                               {OUT_sf, "OUT_sf", 3},
-                                                               {OUT_mask, "OUT_mask", 4}});
-    torch::checkDeviceType("fusedQuantizeMxQuestWithMask", {A, B, OUT, OUT_sf, OUT_mask}, at::DeviceType::CUDA);
-    torch::checkAllSameGPU("fusedQuantizeMxQuestWithMask", {{A, "A", 0},
-                                                            {B, "B", 1},
-                                                            {OUT, "OUT", 2},
-                                                            {OUT_sf, "OUT_sf", 3},
-                                                            {OUT_mask, "OUT_mask", 4}});
-    TORCH_CHECK(A.scalar_type() == at::kBFloat16, "A must be bf16");
-    TORCH_CHECK(B.scalar_type() == at::kBFloat16, "B must be bf16");
-    TORCH_CHECK(B.size(0) == B.size(1), "Rotation matrix must be square");
+    check_all_contiguous("fusedQuantizeMxQuestWithMask", {{A, "A", 0},
+                                                          {B, "B", 1},
+                                                          {OUT, "OUT", 2},
+                                                          {OUT_sf, "OUT_sf", 3},
+                                                          {OUT_mask, "OUT_mask", 4}});
+    check_device_type_cuda("fusedQuantizeMxQuestWithMask", {A, B, OUT, OUT_sf, OUT_mask});
+    check_all_same_gpu("fusedQuantizeMxQuestWithMask", {{A, "A", 0},
+                                                        {B, "B", 1},
+                                                        {OUT, "OUT", 2},
+                                                        {OUT_sf, "OUT_sf", 3},
+                                                        {OUT_mask, "OUT_mask", 4}});
+    STD_TORCH_CHECK(A.scalar_type() == ScalarType::BFloat16, "A must be bf16");
+    STD_TORCH_CHECK(B.scalar_type() == ScalarType::BFloat16, "B must be bf16");
+    STD_TORCH_CHECK(B.size(0) == B.size(1), "Rotation matrix must be square");
 
     uint32_t HAD_GS = B.size(0);
-    TORCH_CHECK((A.numel()%HAD_GS)==0, "A must be divisible by", HAD_GS);
+    STD_TORCH_CHECK((A.numel() % HAD_GS) == 0, "A must be divisible by", HAD_GS);
 
-    if(HAD_GS==32){
+    if (HAD_GS == 32) {
         fusedQuantizeMxQuestWithMask_host(OUT, OUT_sf, OUT_mask, A, B);
     } else {
-        TORCH_CHECK(false,
-                    "Unsupported rotation size ", HAD_GS,
-                    "; expected 32.");
+        STD_TORCH_CHECK(false,
+                        "Unsupported rotation size ", HAD_GS,
+                        "; expected 32.");
     }
 
     return std::make_tuple(OUT, OUT_sf, OUT_mask);
 }
 
-std::tuple<torch::Tensor, torch::Tensor> fusedQuantizeMxAbsMax(torch::Tensor const& A,
-                                                               torch::Tensor const& B,
-                                                               torch::Tensor& OUT,
-                                                               torch::Tensor& OUT_sf)
+std::tuple<Tensor, Tensor> fusedQuantizeMxAbsMax(Tensor const& A,
+                                                 Tensor const& B,
+                                                 Tensor& OUT,
+                                                 Tensor& OUT_sf)
 {
-    torch::checkAllContiguous("fusedQuantizeMxAbsMax", {{A, "A", 0},
-                                                        {B, "B", 1},
-                                                        {OUT, "OUT", 2},
-                                                        {OUT_sf, "OUT_sf", 3}});
-    torch::checkDeviceType("fusedQuantizeMxAbsMax", {A, B, OUT, OUT_sf}, at::DeviceType::CUDA);
-    torch::checkAllSameGPU("fusedQuantizeMxAbsMax", {{A, "A", 0},
-                                                     {B, "B", 1},
-                                                     {OUT, "OUT", 2},
-                                                     {OUT_sf, "OUT_sf", 3}});
-    TORCH_CHECK(A.scalar_type() == at::kBFloat16, "A must be bf16");
-    TORCH_CHECK(B.scalar_type() == at::kBFloat16, "B must be bf16");
-    TORCH_CHECK(B.size(0) == B.size(1), "Rotation matrix must be square");
+    check_all_contiguous("fusedQuantizeMxAbsMax", {{A, "A", 0},
+                                                   {B, "B", 1},
+                                                   {OUT, "OUT", 2},
+                                                   {OUT_sf, "OUT_sf", 3}});
+    check_device_type_cuda("fusedQuantizeMxAbsMax", {A, B, OUT, OUT_sf});
+    check_all_same_gpu("fusedQuantizeMxAbsMax", {{A, "A", 0},
+                                                 {B, "B", 1},
+                                                 {OUT, "OUT", 2},
+                                                 {OUT_sf, "OUT_sf", 3}});
+    STD_TORCH_CHECK(A.scalar_type() == ScalarType::BFloat16, "A must be bf16");
+    STD_TORCH_CHECK(B.scalar_type() == ScalarType::BFloat16, "B must be bf16");
+    STD_TORCH_CHECK(B.size(0) == B.size(1), "Rotation matrix must be square");
 
     uint32_t HAD_GS = B.size(0);
-    TORCH_CHECK((A.numel()%HAD_GS)==0, "A must be divisible by", HAD_GS);
+    STD_TORCH_CHECK((A.numel() % HAD_GS) == 0, "A must be divisible by", HAD_GS);
 
-    if(HAD_GS==32){
+    if (HAD_GS == 32) {
         fusedQuantizeMxAbsMax_host(OUT, OUT_sf, A, B);
-    } else if(HAD_GS==64){
+    } else if (HAD_GS == 64) {
         fusedQuantizeMxAbsMaxHad64_host(OUT, OUT_sf, A, B);
-    } else if(HAD_GS==128){
+    } else if (HAD_GS == 128) {
 #if TARGET_CUDA_ARCH == 100
-        auto opts = torch::TensorOptions().dtype(torch::kFloat).device(A.device());
-        auto global_scale = torch::tensor(0.0f, opts); //FIXME: add input global_scale to interface for consistency
+        auto global_scale =
+            torch::stable::new_zeros(A, {1}, ScalarType::Float);
         fusedQuantizeMxAbsMax_host_sm100(OUT, OUT_sf, A, B, global_scale);
 #elif TARGET_CUDA_ARCH == 120
         fusedQuantizeMxAbsMaxHad128_host(OUT, OUT_sf, A, B);
 #endif
-
     } else {
-        TORCH_CHECK(false,
-                    "Unsupported rotation size ", HAD_GS,
-                    "; expected 32, 64, or 128.");
+        STD_TORCH_CHECK(false,
+                        "Unsupported rotation size ", HAD_GS,
+                        "; expected 32, 64, or 128.");
     }
 
     return std::make_tuple(OUT, OUT_sf);
 }
 
-std::tuple<torch::Tensor, torch::Tensor> fusedQuantizeNvQuest(torch::Tensor const& A,
-                                                         torch::Tensor const& B,
-                                                         torch::Tensor& OUT,
-                                                         torch::Tensor& OUT_sf,
-                                                         torch::Tensor const& global_scale)
+std::tuple<Tensor, Tensor> fusedQuantizeNvQuest(Tensor const& A,
+                                                Tensor const& B,
+                                                Tensor& OUT,
+                                                Tensor& OUT_sf,
+                                                Tensor const& global_scale)
 {
-    torch::checkAllContiguous("fusedQuantizeNvQuest", {{A, "A", 0},
+    check_all_contiguous("fusedQuantizeNvQuest", {{A, "A", 0},
                                                   {B, "B", 1},
                                                   {OUT, "OUT", 2},
                                                   {OUT_sf, "OUT_sf", 3}});
-    torch::checkDeviceType("fusedQuantizeNvQuest", {A, B, OUT, OUT_sf, global_scale}, at::DeviceType::CUDA);
-    torch::checkAllSameGPU("fusedQuantizeNvQuest", {{A, "A", 0},
-                                               {B, "B", 1},
-                                               {OUT, "OUT", 2},
-                                               {OUT_sf, "OUT_sf", 3},
-                                               {global_scale, "global_scale", 4}});
-    TORCH_CHECK(A.scalar_type() == at::kBFloat16, "A must be bf16");
-    TORCH_CHECK(B.scalar_type() == at::kBFloat16, "B must be bf16");
-    TORCH_CHECK(global_scale.scalar_type() == at::kFloat, "global_scale must be float");
-    TORCH_CHECK(global_scale.dim() == 1 && global_scale.size(0) == 1, "global_scale must be a scalar");
-    TORCH_CHECK(B.size(0) == B.size(1), "Rotation matrix must be square");
+    check_device_type_cuda("fusedQuantizeNvQuest",
+                           {A, B, OUT, OUT_sf, global_scale});
+    check_all_same_gpu("fusedQuantizeNvQuest", {{A, "A", 0},
+                                                {B, "B", 1},
+                                                {OUT, "OUT", 2},
+                                                {OUT_sf, "OUT_sf", 3},
+                                                {global_scale, "global_scale", 4}});
+    STD_TORCH_CHECK(A.scalar_type() == ScalarType::BFloat16, "A must be bf16");
+    STD_TORCH_CHECK(B.scalar_type() == ScalarType::BFloat16, "B must be bf16");
+    STD_TORCH_CHECK(global_scale.scalar_type() == ScalarType::Float,
+                    "global_scale must be float");
+    STD_TORCH_CHECK(global_scale.dim() == 1 && global_scale.size(0) == 1,
+                    "global_scale must be a scalar");
+    STD_TORCH_CHECK(B.size(0) == B.size(1), "Rotation matrix must be square");
 
     uint32_t HAD_GS = B.size(0);
-    TORCH_CHECK((A.numel()%HAD_GS)==0, "A must be divisible by", HAD_GS);
+    STD_TORCH_CHECK((A.numel() % HAD_GS) == 0, "A must be divisible by", HAD_GS);
 
-    if(HAD_GS==16){
+    if (HAD_GS == 16) {
         fusedQuantizeNvQuest_host(OUT, OUT_sf, A, B, global_scale);
-    } else if(HAD_GS==32){
+    } else if (HAD_GS == 32) {
         fusedQuantizeNvQuestHad32_host(OUT, OUT_sf, A, B, global_scale);
-    } else if(HAD_GS==64){
+    } else if (HAD_GS == 64) {
         fusedQuantizeNvQuestHad64_host(OUT, OUT_sf, A, B, global_scale);
-    } else if(HAD_GS==128){
+    } else if (HAD_GS == 128) {
         fusedQuantizeNvQuestHad128_host(OUT, OUT_sf, A, B, global_scale);
     } else {
-        TORCH_CHECK(false,
-                    "Unsupported rotation size ", HAD_GS,
-                    "; expected 16, 32, 64, or 128.");
+        STD_TORCH_CHECK(false,
+                        "Unsupported rotation size ", HAD_GS,
+                        "; expected 16, 32, 64, or 128.");
     }
 
     return std::make_tuple(OUT, OUT_sf);
 }
 
-std::tuple<torch::Tensor, torch::Tensor> fusedQuantizeNvAbsMax(torch::Tensor const& A,
-                                                         torch::Tensor const& B,
-                                                         torch::Tensor& OUT,
-                                                         torch::Tensor& OUT_sf,
-                                                         torch::Tensor const& global_scale)
+std::tuple<Tensor, Tensor> fusedQuantizeNvAbsMax(Tensor const& A,
+                                                 Tensor const& B,
+                                                 Tensor& OUT,
+                                                 Tensor& OUT_sf,
+                                                 Tensor const& global_scale)
 {
-    torch::checkAllContiguous("fusedQuantizeNvAbsMax", {{A, "A", 0},
-                                                  {B, "B", 1},
-                                                  {OUT, "OUT", 2},
-                                                  {OUT_sf, "OUT_sf", 3}});
-    torch::checkDeviceType("fusedQuantizeNvAbsMax", {A, B, OUT, OUT_sf, global_scale}, at::DeviceType::CUDA);
-    torch::checkAllSameGPU("fusedQuantizeNvAbsMax", {{A, "A", 0},
-                                               {B, "B", 1},
-                                               {OUT, "OUT", 2},
-                                               {OUT_sf, "OUT_sf", 3},
-                                               {global_scale, "global_scale", 4}});
-    TORCH_CHECK(A.scalar_type() == at::kBFloat16, "A must be bf16");
-    TORCH_CHECK(B.scalar_type() == at::kBFloat16, "B must be bf16");
-    TORCH_CHECK(global_scale.scalar_type() == at::kFloat, "global_scale must be float");
-    TORCH_CHECK(global_scale.dim() == 1 && global_scale.size(0) == 1, "global_scale must be a scalar");
-    TORCH_CHECK(B.size(0) == B.size(1), "Rotation matrix must be square");
+    check_all_contiguous("fusedQuantizeNvAbsMax", {{A, "A", 0},
+                                                   {B, "B", 1},
+                                                   {OUT, "OUT", 2},
+                                                   {OUT_sf, "OUT_sf", 3}});
+    check_device_type_cuda("fusedQuantizeNvAbsMax", {A, B, OUT, OUT_sf, global_scale});
+    check_all_same_gpu("fusedQuantizeNvAbsMax", {{A, "A", 0},
+                                                 {B, "B", 1},
+                                                 {OUT, "OUT", 2},
+                                                 {OUT_sf, "OUT_sf", 3},
+                                                 {global_scale, "global_scale", 4}});
+    STD_TORCH_CHECK(A.scalar_type() == ScalarType::BFloat16, "A must be bf16");
+    STD_TORCH_CHECK(B.scalar_type() == ScalarType::BFloat16, "B must be bf16");
+    STD_TORCH_CHECK(global_scale.scalar_type() == ScalarType::Float,
+                    "global_scale must be float");
+    STD_TORCH_CHECK(global_scale.dim() == 1 && global_scale.size(0) == 1,
+                    "global_scale must be a scalar");
+    STD_TORCH_CHECK(B.size(0) == B.size(1), "Rotation matrix must be square");
 
     uint32_t HAD_GS = B.size(0);
-    TORCH_CHECK((A.numel()%HAD_GS)==0, "A must be divisible by", HAD_GS);
+    STD_TORCH_CHECK((A.numel() % HAD_GS) == 0, "A must be divisible by", HAD_GS);
 
-    if(HAD_GS==16){
+    if (HAD_GS == 16) {
         fusedQuantizeNvAbsMax_host(OUT, OUT_sf, A, B, global_scale);
-    } else if(HAD_GS==32){
+    } else if (HAD_GS == 32) {
         fusedQuantizeNvAbsMaxHad32_host(OUT, OUT_sf, A, B, global_scale);
-    } else if(HAD_GS==64){
+    } else if (HAD_GS == 64) {
         fusedQuantizeNvAbsMaxHad64_host(OUT, OUT_sf, A, B, global_scale);
-    } else if(HAD_GS==128){
+    } else if (HAD_GS == 128) {
 #if TARGET_CUDA_ARCH == 100
         fusedQuantizeNvAbsMax_host_sm100(OUT, OUT_sf, A, B, global_scale);
 #elif TARGET_CUDA_ARCH == 120
         fusedQuantizeNvAbsMaxHad128_host(OUT, OUT_sf, A, B, global_scale);
 #endif
     } else {
-        TORCH_CHECK(false,
-                    "Unsupported rotation size ", HAD_GS,
-                    "; expected 16, 32, 64, or 128.");
+        STD_TORCH_CHECK(false,
+                        "Unsupported rotation size ", HAD_GS,
+                        "; expected 16, 32, 64, or 128.");
     }
 
     return std::make_tuple(OUT, OUT_sf);
 }
 
-void backward_t_bf16(const torch::Tensor& x,
-                     const torch::Tensor& h,
-                     torch::Tensor& xh_e2m1,
-                     torch::Tensor& xh_e8m0)
-{
-    int err = backward_t_bf16_cuda(
-        x.data_ptr(),
-        h.data_ptr(),
-        xh_e2m1.data_ptr(),
-        xh_e8m0.data_ptr(),
-        x.size(-1),
-        x.size(-2),
-        x.numel() / (x.size(-2) * x.size(-1)),
-        at::cuda::getCurrentCUDAStream(h.device().index())
-    );
+}  // namespace QUTLASS
+
+STABLE_TORCH_LIBRARY_FRAGMENT(_qutlass_C, ops) {
+  ops.def("matmul_mxf4_bf16_tn(Tensor A, Tensor B, Tensor A_sf, Tensor B_sf, Tensor alpha) -> Tensor");
+  ops.def("matmul_nvf4_bf16_tn(Tensor A, Tensor B, Tensor A_sf, Tensor B_sf, Tensor alpha) -> Tensor");
+  ops.def("matmul_ada_mxf4_bf16_tn(Tensor A, Tensor B, Tensor A_sf, Tensor B_sf, Tensor alpha) -> Tensor");
+  ops.def("fusedQuantizeMxQuest(Tensor A, Tensor R, Tensor OUT, Tensor OUT_sf) -> (Tensor, Tensor)");
+  ops.def("fusedQuantizeMxQuestWithMask(Tensor A, Tensor R, Tensor OUT, Tensor OUT_sf, Tensor OUT_mask) -> (Tensor, Tensor, Tensor)");
+  ops.def("fusedQuantizeMxAbsMax(Tensor A, Tensor R, Tensor OUT, Tensor OUT_sf) -> (Tensor, Tensor)");
+  ops.def("fusedQuantizeNvQuest(Tensor A, Tensor R, Tensor OUT, Tensor OUT_sf, Tensor global_scale) -> (Tensor, Tensor)");
+  ops.def("fusedQuantizeNvAbsMax(Tensor A, Tensor R, Tensor OUT, Tensor OUT_sf, Tensor global_scale) -> (Tensor, Tensor)");
 }
 
-void backward_qt_bf16(const torch::Tensor& x_e2m1,
-                      const torch::Tensor& x_e8m0,
-                      const torch::Tensor& h,
-                      const torch::Tensor& alpha,
-                      torch::Tensor& xh_e2m1,
-                      torch::Tensor& xh_e8m0) {
-    int err = backward_qt_bf16_cuda(
-        x_e2m1.data_ptr(),
-        x_e8m0.data_ptr(),
-        h.data_ptr(),
-        alpha.data_ptr(),
-        xh_e2m1.data_ptr(),
-        xh_e8m0.data_ptr(),
-        x_e2m1.size(-1) * 2,
-        x_e2m1.size(-2),
-        x_e2m1.numel() / (x_e2m1.size(-2) * x_e2m1.size(-1)),
-        at::cuda::getCurrentCUDAStream(h.device().index())
-    );
-}
-
-void backward_bf16_square_double_mxfp8(const torch::Tensor& x_bf16,
-    torch::Tensor& x_fp8,
-    torch::Tensor& row_scales,
-    torch::Tensor& column_scales) {
-    int err = backward_bf16_square_double_mxfp8_cuda(
-        x_bf16.data_ptr(),
-        x_bf16.size(0),
-        x_bf16.size(1),
-        x_fp8.data_ptr(),
-        row_scales.data_ptr(),
-        column_scales.data_ptr(),
-        at::cuda::getCurrentCUDAStream(x_bf16.device().index())
-    );
-}
-
-void mxfp4_transpose_mxfp8(const torch::Tensor& x_fp4,
-    const torch::Tensor& scales,
-    torch::Tensor& x_fp8,
-    torch::Tensor& shared_exps) {
-    int err = mxfp4_transpose_mxfp8_cuda(
-        x_fp4.data_ptr(),
-        scales.data_ptr(),
-        x_fp4.size(0),
-        x_fp4.size(1) * 2,
-        x_fp8.data_ptr(),
-        shared_exps.data_ptr(),
-        at::cuda::getCurrentCUDAStream(x_fp4.device().index())
-    );
-}
-
-
-TORCH_LIBRARY(_qutlass_C, m) {
-  m.def("matmul_mxf4_bf16_tn(Tensor A, Tensor B, Tensor A_sf, Tensor B_sf, Tensor alpha) -> Tensor");
-  m.def("matmul_nvf4_bf16_tn(Tensor A, Tensor B, Tensor A_sf, Tensor B_sf, Tensor alpha) -> Tensor");
-  m.def("matmul_ada_mxf4_bf16_tn(Tensor A, Tensor B, Tensor A_sf, Tensor B_sf, Tensor alpha) -> Tensor");
-
-  m.def("fusedQuantizeMxQuest(Tensor A, Tensor R, Tensor OUT, Tensor OUT_sf) -> (Tensor, Tensor)");
-  m.def("fusedQuantizeMxQuestWithMask(Tensor A, Tensor R, Tensor OUT, Tensor OUT_sf, Tensor OUT_mask) -> (Tensor, Tensor, Tensor)");
-  m.def("fusedQuantizeMxAbsMax(Tensor A, Tensor R, Tensor OUT, Tensor OUT_sf) -> (Tensor, Tensor)");
-  m.def("fusedQuantizeNvQuest(Tensor A, Tensor R, Tensor OUT, Tensor OUT_sf, Tensor global_scale) -> (Tensor, Tensor)");
-  m.def("fusedQuantizeNvAbsMax(Tensor A, Tensor R, Tensor OUT, Tensor OUT_sf, Tensor global_scale) -> (Tensor, Tensor)");
-
-  //m.def("backward_t_bf16(Tensor x_e2m1, Tensor x_e8m0, Tensor h, float alpha, Tensor xh_e2m1, Tensor xh_e8m0) -> void");
-  //m.def("backward_qt_bf16(Tensor x, Tensor h, Tensor xh_e2m1, Tensor xh_e8m0) -> void");
-}
-
-TORCH_LIBRARY_IMPL(_qutlass_C, CUDA, m) {
-  m.impl("matmul_mxf4_bf16_tn",      TORCH_FN(QUTLASS::matmul_mxf4_bf16_tn));
-  m.impl("matmul_nvf4_bf16_tn",      TORCH_FN(QUTLASS::matmul_nvf4_bf16_tn));
-  m.impl("matmul_ada_mxf4_bf16_tn",  TORCH_FN(QUTLASS::matmul_ada_mxf4_bf16_tn));
-
-  m.impl("fusedQuantizeMxQuest",     TORCH_FN(QUTLASS::fusedQuantizeMxQuest));
-  m.impl("fusedQuantizeMxQuestWithMask", TORCH_FN(QUTLASS::fusedQuantizeMxQuestWithMask));
-  m.impl("fusedQuantizeMxAbsMax",    TORCH_FN(QUTLASS::fusedQuantizeMxAbsMax));
-  m.impl("fusedQuantizeNvQuest",     TORCH_FN(QUTLASS::fusedQuantizeNvQuest));
-  m.impl("fusedQuantizeNvAbsMax",    TORCH_FN(QUTLASS::fusedQuantizeNvAbsMax));
-
-  //m.impl("backward_t_bf16",          TORCH_FN(QUTLASS::backward_t_bf16));
-  //m.impl("backward_qt_bf16",         TORCH_FN(QUTLASS::backward_qt_bf16));
-}
-
-//====== pybind ======
-
-#define DEFINE_pybind(name) m.def(#name, &name, #name);
-
-#ifndef QUTLASS_DISABLE_PYBIND
-PYBIND11_MODULE(TORCH_EXTENSION_NAME, m
-)
-{
-    m.def("matmul_mxf4_bf16_tn",     &matmul_mxf4_bf16_tn,     "matmul_mxf4_bf16_tn");
-    m.def("matmul_ada_mxf4_bf16_tn", &matmul_ada_mxf4_bf16_tn, "matmul_ada_mxf4_bf16_tn");
-    m.def("matmul_nvf4_bf16_tn",     &matmul_nvf4_bf16_tn,     "matmul_nvf4_bf16_tn");
-    m.def("matmul_mxf8_bf16_tn",     &matmul_mxf8_bf16_tn,     "matmul_mxf8_bf16_tn");
-    m.def("matmul_mxf8_bf16_nn",     &matmul_mxf8_bf16_nn,     "matmul_mxf8_bf16_nn");
-
-    m.def("fusedQuantizeMxQuest",  &QUTLASS::fusedQuantizeMxQuest,  "fusedQuantizeMxQuest");
-    m.def("fusedQuantizeMxQuestWithMask",  &QUTLASS::fusedQuantizeMxQuestWithMask,  "fusedQuantizeMxQuestWithMask");
-    m.def("fusedQuantizeMxAbsMax", &QUTLASS::fusedQuantizeMxAbsMax, "fusedQuantizeMxAbsMax");
-    m.def("fusedQuantizeNvQuest",  &QUTLASS::fusedQuantizeNvQuest,  "fusedQuantizeNvQuest");
-    m.def("fusedQuantizeNvAbsMax", &QUTLASS::fusedQuantizeNvAbsMax, "fusedQuantizeNvAbsMax");
-
-    m.def("backward_t_bf16",  &backward_t_bf16,  "backward_t_bf16");
-    m.def("backward_qt_bf16", &backward_qt_bf16, "backward_qt_bf16");
-    m.def("backward_bf16_square_double_mxfp8", &backward_bf16_square_double_mxfp8, "backward_bf16_square_double_mxfp8");
-    m.def("mxfp4_transpose_mxfp8", &mxfp4_transpose_mxfp8, "mxfp4_transpose_mxfp8");
-}
-#endif
+STABLE_TORCH_LIBRARY_IMPL(_qutlass_C, CUDA, ops) {
+  ops.impl("matmul_mxf4_bf16_tn", TORCH_BOX(&QUTLASS::matmul_mxf4_bf16_tn));
+  ops.impl("matmul_nvf4_bf16_tn", TORCH_BOX(&QUTLASS::matmul_nvf4_bf16_tn));
+  ops.impl("matmul_ada_mxf4_bf16_tn", TORCH_BOX(&QUTLASS::matmul_ada_mxf4_bf16_tn));
+  ops.impl("fusedQuantizeMxQuest", TORCH_BOX(&QUTLASS::fusedQuantizeMxQuest));
+  ops.impl("fusedQuantizeMxQuestWithMask", TORCH_BOX(&QUTLASS::fusedQuantizeMxQuestWithMask));
+  ops.impl("fusedQuantizeMxAbsMax", TORCH_BOX(&QUTLASS::fusedQuantizeMxAbsMax));
+  ops.impl("fusedQuantizeNvQuest", TORCH_BOX(&QUTLASS::fusedQuantizeNvQuest));
+  ops.impl("fusedQuantizeNvAbsMax", TORCH_BOX(&QUTLASS::fusedQuantizeNvAbsMax));
 }

--- a/qutlass/csrc/bindings.cpp
+++ b/qutlass/csrc/bindings.cpp
@@ -235,6 +235,7 @@ std::tuple<Tensor, Tensor> fusedQuantizeMxAbsMax(Tensor const& A,
         fusedQuantizeMxAbsMaxHad64_host(OUT, OUT_sf, A, B);
     } else if (HAD_GS == 128) {
 #if TARGET_CUDA_ARCH == 100
+        // FIXME: add input global_scale to interface for consistency
         auto global_scale =
             torch::stable::new_zeros(A, {1}, ScalarType::Float);
         fusedQuantizeMxAbsMax_host_sm100(OUT, OUT_sf, A, B, global_scale);

--- a/qutlass/csrc/fused_quantize_mx.cu
+++ b/qutlass/csrc/fused_quantize_mx.cu
@@ -14,16 +14,6 @@
  * limitations under the License.
  */
 
-#include <ATen/ATen.h>
-#include <torch/types.h>
-#include <ATen/cuda/CUDAContext.h>
-#include <c10/cuda/CUDAGuard.h>
-#include <cuda_runtime.h>
-
-#ifndef QUTLASS_DISABLE_PYBIND
-#include <torch/extension.h>
-#endif
-
 #include <iostream>
 
 #include "cutlass/cutlass.h"
@@ -78,12 +68,12 @@ struct GemmRunner {
   GemmRunner() { }
 
   bool run(
-    torch::Tensor &out,
-    torch::Tensor &out_sf,
-    torch::Tensor const&x,
-    torch::Tensor const&y,
+    torch::stable::Tensor &out,
+    torch::stable::Tensor &out_sf,
+    torch::stable::Tensor const& x,
+    torch::stable::Tensor const& y,
     int32_t M, int32_t N, int32_t K,
-    torch::Device device)
+    torch::stable::Device device)
   {
 
     using GemmCoord = cutlass::gemm::GemmCoord;
@@ -93,16 +83,16 @@ struct GemmRunner {
       {static_cast<GemmCoord::Index>(M),
        static_cast<GemmCoord::Index>(N),
        static_cast<GemmCoord::Index>(K)},
-      {(cutlass::bfloat16_t *)x.data_ptr(), K},
-      {(cutlass::bfloat16_t *)y.data_ptr(), N},
-      {(cutlass::float_e2m1_t *)out.data_ptr(), N},
-      {(cutlass::float_e2m1_t *)out.data_ptr(), N},
-      {(cutlass::float_ue8m0_t *)out_sf.data_ptr(), M},
+      {static_cast<const cutlass::bfloat16_t*>(x.const_data_ptr()), K},
+      {static_cast<const cutlass::bfloat16_t*>(y.const_data_ptr()), N},
+      {static_cast<cutlass::float_e2m1_t*>(out.mutable_data_ptr()), N},
+      {static_cast<cutlass::float_e2m1_t*>(out.mutable_data_ptr()), N},
+      {static_cast<cutlass::float_ue8m0_t*>(out_sf.mutable_data_ptr()), M},
         cutlass::bfloat16_t(0) //TODO (later): float
     };
 
-    const at::cuda::OptionalCUDAGuard device_guard(device_of(x));
-    cudaStream_t stream = at::cuda::getCurrentCUDAStream(device.index());
+    const torch::stable::accelerator::DeviceGuard device_guard(x.get_device_index());
+    cudaStream_t stream = get_current_cuda_stream(device.index());
 
     CUTLASS_CHECK(gemmOp.initialize(arguments, nullptr, stream));
 
@@ -114,10 +104,10 @@ struct GemmRunner {
 };
 
 
-void fusedQuantizeMxQuest_host(torch::Tensor& D,
-                               torch::Tensor& D_sf,
-                               torch::Tensor const& A,
-                               torch::Tensor const& B)
+void fusedQuantizeMxQuest_host(torch::stable::Tensor& D,
+                               torch::stable::Tensor& D_sf,
+                               torch::stable::Tensor const& A,
+                               torch::stable::Tensor const& B)
 {
   int32_t M = A.numel() / 32;
   int32_t N = B.size(1);
@@ -131,10 +121,10 @@ void fusedQuantizeMxQuest_host(torch::Tensor& D,
   bool result = runGemm.run(D, D_sf, A, B, M, N, K, A.device());
 }
 
-void fusedQuantizeMxAbsMax_host(torch::Tensor& D,
-                                torch::Tensor& D_sf,
-                                torch::Tensor const& A,
-                                torch::Tensor const& B)
+void fusedQuantizeMxAbsMax_host(torch::stable::Tensor& D,
+                                torch::stable::Tensor& D_sf,
+                                torch::stable::Tensor const& A,
+                                torch::stable::Tensor const& B)
 {
   int32_t M = A.numel() / 32;
   int32_t N = B.size(1);
@@ -148,10 +138,10 @@ void fusedQuantizeMxAbsMax_host(torch::Tensor& D,
   bool result = runGemm.run(D, D_sf, A, B, M, N, K, A.device());
 }
 
-void fusedQuantizeMxQuestHad64_host(torch::Tensor& D,
-                               torch::Tensor& D_sf,
-                               torch::Tensor const& A,
-                               torch::Tensor const& B)
+void fusedQuantizeMxQuestHad64_host(torch::stable::Tensor& D,
+                               torch::stable::Tensor& D_sf,
+                               torch::stable::Tensor const& A,
+                               torch::stable::Tensor const& B)
 {
   int32_t M = A.numel() / 64;
   int32_t N = B.size(1);
@@ -165,10 +155,10 @@ void fusedQuantizeMxQuestHad64_host(torch::Tensor& D,
   bool result = runGemm.run(D, D_sf, A, B, M, N, K, A.device());
 }
 
-void fusedQuantizeMxAbsMaxHad64_host(torch::Tensor& D,
-                                torch::Tensor& D_sf,
-                                torch::Tensor const& A,
-                                torch::Tensor const& B)
+void fusedQuantizeMxAbsMaxHad64_host(torch::stable::Tensor& D,
+                                torch::stable::Tensor& D_sf,
+                                torch::stable::Tensor const& A,
+                                torch::stable::Tensor const& B)
 {
   int32_t M = A.numel() / 64;
   int32_t N = B.size(1);
@@ -182,10 +172,10 @@ void fusedQuantizeMxAbsMaxHad64_host(torch::Tensor& D,
   bool result = runGemm.run(D, D_sf, A, B, M, N, K, A.device());
 }
 
-void fusedQuantizeMxQuestHad128_host(torch::Tensor& D,
-                               torch::Tensor& D_sf,
-                               torch::Tensor const& A,
-                               torch::Tensor const& B)
+void fusedQuantizeMxQuestHad128_host(torch::stable::Tensor& D,
+                               torch::stable::Tensor& D_sf,
+                               torch::stable::Tensor const& A,
+                               torch::stable::Tensor const& B)
 {
   int32_t M = A.numel() / 128;
   int32_t N = B.size(1);
@@ -199,10 +189,10 @@ void fusedQuantizeMxQuestHad128_host(torch::Tensor& D,
   bool result = runGemm.run(D, D_sf, A, B, M, N, K, A.device());
 }
 
-void fusedQuantizeMxAbsMaxHad128_host(torch::Tensor& D,
-                                torch::Tensor& D_sf,
-                                torch::Tensor const& A,
-                                torch::Tensor const& B)
+void fusedQuantizeMxAbsMaxHad128_host(torch::stable::Tensor& D,
+                                torch::stable::Tensor& D_sf,
+                                torch::stable::Tensor const& A,
+                                torch::stable::Tensor const& B)
 {
   int32_t M = A.numel() / 128;
   int32_t N = B.size(1);

--- a/qutlass/csrc/fused_quantize_mx_mask.cu
+++ b/qutlass/csrc/fused_quantize_mx_mask.cu
@@ -14,16 +14,6 @@
  * limitations under the License.
  */
 
-#include <ATen/ATen.h>
-#include <torch/types.h>
-#include <ATen/cuda/CUDAContext.h>
-#include <c10/cuda/CUDAGuard.h>
-#include <cuda_runtime.h>
-
-#ifndef QUTLASS_DISABLE_PYBIND
-#include <torch/extension.h>
-#endif
-
 #include <iostream>
 
 #include "cutlass/cutlass.h"
@@ -76,13 +66,13 @@ struct GemmRunner {
   GemmRunner() { }
 
   bool run(
-    torch::Tensor &out,
-    torch::Tensor &out_sf,
-    torch::Tensor &out_mask,
-    torch::Tensor const&x,
-    torch::Tensor const&y,
+    torch::stable::Tensor &out,
+    torch::stable::Tensor &out_sf,
+    torch::stable::Tensor &out_mask,
+    torch::stable::Tensor const& x,
+    torch::stable::Tensor const& y,
     int32_t M, int32_t N, int32_t K,
-    torch::Device device)
+    torch::stable::Device device)
   {
 
     using GemmCoord = cutlass::gemm::GemmCoord;
@@ -92,17 +82,17 @@ struct GemmRunner {
       {static_cast<GemmCoord::Index>(M),
        static_cast<GemmCoord::Index>(N),
        static_cast<GemmCoord::Index>(K)},
-      {(cutlass::bfloat16_t *)x.data_ptr(), K},
-      {(cutlass::bfloat16_t *)y.data_ptr(), N},
-      {(cutlass::float_e2m1_t *)out.data_ptr(), N},
-      {(cutlass::float_e2m1_t *)out.data_ptr(), N},
-      {(cutlass::float_ue8m0_t *)out_sf.data_ptr(), M},
-      {(uint8_t *)out_mask.data_ptr(), M}, //FIXME: bfloat16_t
+      {static_cast<const cutlass::bfloat16_t*>(x.const_data_ptr()), K},
+      {static_cast<const cutlass::bfloat16_t*>(y.const_data_ptr()), N},
+      {static_cast<cutlass::float_e2m1_t*>(out.mutable_data_ptr()), N},
+      {static_cast<cutlass::float_e2m1_t*>(out.mutable_data_ptr()), N},
+      {static_cast<cutlass::float_ue8m0_t*>(out_sf.mutable_data_ptr()), M},
+      {static_cast<uint8_t*>(out_mask.mutable_data_ptr()), M}, //FIXME: bfloat16_t
         cutlass::bfloat16_t(0) //TODO (later): float
     };
 
-    const at::cuda::OptionalCUDAGuard device_guard(device_of(x));
-    cudaStream_t stream = at::cuda::getCurrentCUDAStream(device.index());
+    const torch::stable::accelerator::DeviceGuard device_guard(x.get_device_index());
+    cudaStream_t stream = get_current_cuda_stream(device.index());
 
     CUTLASS_CHECK(gemmOp.initialize(arguments, nullptr, stream));
 
@@ -113,11 +103,11 @@ struct GemmRunner {
 
 };
 
-void fusedQuantizeMxQuestWithMask_host(torch::Tensor& D,
-                                       torch::Tensor& D_sf,
-                                       torch::Tensor& D_mask,
-                                       torch::Tensor const& A,
-                                       torch::Tensor const& B)
+void fusedQuantizeMxQuestWithMask_host(torch::stable::Tensor& D,
+                                       torch::stable::Tensor& D_sf,
+                                       torch::stable::Tensor& D_mask,
+                                       torch::stable::Tensor const& A,
+                                       torch::stable::Tensor const& B)
 {
   int32_t M = A.numel() / 32;
   int32_t N = B.size(1);

--- a/qutlass/csrc/fused_quantize_mx_sm100.cu
+++ b/qutlass/csrc/fused_quantize_mx_sm100.cu
@@ -14,16 +14,6 @@
  * limitations under the License.
  */
 
-#include <ATen/ATen.h>
-#include <torch/types.h>
-#include <ATen/cuda/CUDAContext.h>
-#include <c10/cuda/CUDAGuard.h>
-#include <cuda_runtime.h>
-
-#ifndef QUTLASS_DISABLE_PYBIND
-#include <torch/extension.h>
-#endif
-
 #include "cutlass/cutlass.h"
 #include "cute/tensor.hpp"
 #include "cutlass/tensor_ref.h"
@@ -128,11 +118,11 @@ constexpr bool IsBlockScaleSupported = FusionOp::IsBlockScaleSupported;
 using SfdOutputCfg = cutlass::detail::Sm1xxBlockScaledOutputConfig<OutputSFVectorSize>;
 using LayoutSFD = typename SfdOutputCfg::LayoutSF;
 
-typename Gemm::Arguments args_from_options(torch::Tensor& D,
-                                           torch::Tensor& D_sf,
-                                           torch::Tensor const& A,
-                                           torch::Tensor const& B,
-                                           torch::Tensor const& global_scale,
+typename Gemm::Arguments args_from_options(torch::stable::Tensor& D,
+                                           torch::stable::Tensor& D_sf,
+                                           torch::stable::Tensor const& A,
+                                           torch::stable::Tensor const& B,
+                                           torch::stable::Tensor const& global_scale,
                                            int32_t M, int32_t N, int32_t K)
 {
     using ElementA       = typename Gemm::ElementA;
@@ -155,30 +145,30 @@ typename Gemm::Arguments args_from_options(torch::Tensor& D,
         cutlass::gemm::GemmUniversalMode::kGemm,
         {M, N, K, 1},
         {
-            static_cast<ElementA const*>(A.data_ptr()),      stride_A,
-            static_cast<ElementB const*>(B.data_ptr()),      stride_B},
+            static_cast<ElementA const*>(A.const_data_ptr()),      stride_A,
+            static_cast<ElementB const*>(B.const_data_ptr()),      stride_B},
         {
             {1.f, 0.f},
             nullptr, stride_C,
-            static_cast<ElementD*>(D.data_ptr()),       stride_D
+            static_cast<ElementD*>(D.mutable_data_ptr()),       stride_D
         }
     };
 
     if constexpr (IsBlockScaleSupported) {
-        arguments.epilogue.thread.block_scale_factor_ptr = static_cast<cutlass::float_ue8m0_t*>(D_sf.data_ptr());
-        arguments.epilogue.thread.norm_constant_ptr      = static_cast<ElementAccumulator const*>(global_scale.data_ptr());;
+        arguments.epilogue.thread.block_scale_factor_ptr = static_cast<cutlass::float_ue8m0_t*>(D_sf.mutable_data_ptr());
+        arguments.epilogue.thread.norm_constant_ptr      = static_cast<ElementAccumulator const*>(global_scale.const_data_ptr());
     }
 
     return arguments;
 }
 
-void runGemm(torch::Tensor& D,
-             torch::Tensor& D_sf,
-             torch::Tensor const& A,
-             torch::Tensor const& B,
-             torch::Tensor const& global_scale,
+void runGemm(torch::stable::Tensor& D,
+             torch::stable::Tensor& D_sf,
+             torch::stable::Tensor const& A,
+             torch::stable::Tensor const& B,
+             torch::stable::Tensor const& global_scale,
              int32_t M, int32_t N, int32_t K,
-             torch::Device device)
+             torch::stable::Device device)
 {
     Gemm gemm;
 
@@ -189,8 +179,8 @@ void runGemm(torch::Tensor& D,
 
     cutlass::device_memory::allocation<uint8_t> workspace(workspace_size);
 
-    const at::cuda::OptionalCUDAGuard device_guard(device_of(A));
-    cudaStream_t stream = at::cuda::getCurrentCUDAStream(device.index());
+    const torch::stable::accelerator::DeviceGuard device_guard(A.get_device_index());
+    cudaStream_t stream = get_current_cuda_stream(device.index());
 
     CUTLASS_CHECK(gemm.can_implement(arguments));
 
@@ -199,11 +189,11 @@ void runGemm(torch::Tensor& D,
     CUTLASS_CHECK(gemm.run(arguments, workspace.get(), stream));
 }
 
-void fusedQuantizeMxAbsMax_host_sm100(torch::Tensor& D,
-                                      torch::Tensor& D_sf,
-                                      torch::Tensor const& A,
-                                      torch::Tensor const& B,
-                                      torch::Tensor const& global_scale)
+void fusedQuantizeMxAbsMax_host_sm100(torch::stable::Tensor& D,
+                                      torch::stable::Tensor& D_sf,
+                                      torch::stable::Tensor const& A,
+                                      torch::stable::Tensor const& B,
+                                      torch::stable::Tensor const& global_scale)
 {
 #if TARGET_CUDA_ARCH == 100
     int32_t M = A.numel() / 128;
@@ -212,7 +202,7 @@ void fusedQuantizeMxAbsMax_host_sm100(torch::Tensor& D,
 
     runGemm(D, D_sf, A, B, global_scale, M, N, K, A.device());
 #else
-    TORCH_CHECK(false, "Unsupported CUDA arch");
+    STD_TORCH_CHECK(false, "Unsupported CUDA arch");
 #endif
 }
 

--- a/qutlass/csrc/fused_quantize_nv.cu
+++ b/qutlass/csrc/fused_quantize_nv.cu
@@ -14,16 +14,6 @@
  * limitations under the License.
  */
 
-#include <ATen/ATen.h>
-#include <torch/types.h>
-#include <ATen/cuda/CUDAContext.h>
-#include <c10/cuda/CUDAGuard.h>
-#include <cuda_runtime.h>
-
-#ifndef QUTLASS_DISABLE_PYBIND
-#include <torch/extension.h>
-#endif
-
 #include <iostream>
 
 #include "cutlass/cutlass.h"
@@ -78,13 +68,13 @@ struct GemmRunner {
   GemmRunner() { }
 
   bool run(
-    torch::Tensor &out,
-    torch::Tensor &out_sf,
-    torch::Tensor const&x,
-    torch::Tensor const&y,
+    torch::stable::Tensor &out,
+    torch::stable::Tensor &out_sf,
+    torch::stable::Tensor const& x,
+    torch::stable::Tensor const& y,
     int32_t M, int32_t N, int32_t K,
-    torch::Device device,
-    torch::Tensor const& global_scale)
+    torch::stable::Device device,
+    torch::stable::Tensor const& global_scale)
   {
 
     using GemmCoord = cutlass::gemm::GemmCoord;
@@ -94,17 +84,17 @@ struct GemmRunner {
       {static_cast<GemmCoord::Index>(M),
        static_cast<GemmCoord::Index>(N),
        static_cast<GemmCoord::Index>(K)},
-      {(cutlass::bfloat16_t *)x.data_ptr(), K},
-      {(cutlass::bfloat16_t *)y.data_ptr(), N},
-      {(cutlass::float_e2m1_t *)out.data_ptr(), N},
-      {(cutlass::float_e2m1_t *)out.data_ptr(), N},
-      {(cutlass::float_ue4m3_t *)out_sf.data_ptr(), M},
-      static_cast<ElementAccumulator*>(global_scale.data_ptr()),
+      {static_cast<const cutlass::bfloat16_t*>(x.const_data_ptr()), K},
+      {static_cast<const cutlass::bfloat16_t*>(y.const_data_ptr()), N},
+      {static_cast<cutlass::float_e2m1_t*>(out.mutable_data_ptr()), N},
+      {static_cast<cutlass::float_e2m1_t*>(out.mutable_data_ptr()), N},
+      {static_cast<cutlass::float_ue4m3_t*>(out_sf.mutable_data_ptr()), M},
+      static_cast<ElementAccumulator*>(const_cast<void*>(global_scale.const_data_ptr())),
       cutlass::bfloat16_t(0) //TODO (later): float
     };
 
-    const at::cuda::OptionalCUDAGuard device_guard(device_of(x));
-    cudaStream_t stream = at::cuda::getCurrentCUDAStream(device.index());
+    const torch::stable::accelerator::DeviceGuard device_guard(x.get_device_index());
+    cudaStream_t stream = get_current_cuda_stream(device.index());
 
     CUTLASS_CHECK(gemmOp.initialize(arguments, nullptr, stream));
 
@@ -116,11 +106,11 @@ struct GemmRunner {
 };
 
 
-void fusedQuantizeNvQuest_host(torch::Tensor& D,
-                        torch::Tensor& D_sf,
-                        torch::Tensor const& A,
-                        torch::Tensor const& B,
-                        torch::Tensor const& global_scale)
+void fusedQuantizeNvQuest_host(torch::stable::Tensor& D,
+                        torch::stable::Tensor& D_sf,
+                        torch::stable::Tensor const& A,
+                        torch::stable::Tensor const& B,
+                        torch::stable::Tensor const& global_scale)
 {
   int32_t M = A.numel() / 16;
   int32_t N = B.size(1);
@@ -134,11 +124,11 @@ void fusedQuantizeNvQuest_host(torch::Tensor& D,
   bool result = runGemm.run(D, D_sf, A, B, M, N, K, A.device(), global_scale);
 }
 
-void fusedQuantizeNvQuestHad32_host(torch::Tensor& D,
-                        torch::Tensor& D_sf,
-                        torch::Tensor const& A,
-                        torch::Tensor const& B,
-                        torch::Tensor const& global_scale)
+void fusedQuantizeNvQuestHad32_host(torch::stable::Tensor& D,
+                        torch::stable::Tensor& D_sf,
+                        torch::stable::Tensor const& A,
+                        torch::stable::Tensor const& B,
+                        torch::stable::Tensor const& global_scale)
 {
   int32_t M = A.numel() / 32;
   int32_t N = B.size(1);
@@ -152,11 +142,11 @@ void fusedQuantizeNvQuestHad32_host(torch::Tensor& D,
   bool result = runGemm.run(D, D_sf, A, B, M, N, K, A.device(), global_scale);
 }
 
-void fusedQuantizeNvQuestHad64_host(torch::Tensor& D,
-                        torch::Tensor& D_sf,
-                        torch::Tensor const& A,
-                        torch::Tensor const& B,
-                        torch::Tensor const& global_scale)
+void fusedQuantizeNvQuestHad64_host(torch::stable::Tensor& D,
+                        torch::stable::Tensor& D_sf,
+                        torch::stable::Tensor const& A,
+                        torch::stable::Tensor const& B,
+                        torch::stable::Tensor const& global_scale)
 {
   int32_t M = A.numel() / 64;
   int32_t N = B.size(1);
@@ -170,11 +160,11 @@ void fusedQuantizeNvQuestHad64_host(torch::Tensor& D,
   bool result = runGemm.run(D, D_sf, A, B, M, N, K, A.device(), global_scale);
 }
 
-void fusedQuantizeNvQuestHad128_host(torch::Tensor& D,
-                        torch::Tensor& D_sf,
-                        torch::Tensor const& A,
-                        torch::Tensor const& B,
-                        torch::Tensor const& global_scale)
+void fusedQuantizeNvQuestHad128_host(torch::stable::Tensor& D,
+                        torch::stable::Tensor& D_sf,
+                        torch::stable::Tensor const& A,
+                        torch::stable::Tensor const& B,
+                        torch::stable::Tensor const& global_scale)
 {
   int32_t M = A.numel() / 128;
   int32_t N = B.size(1);
@@ -188,11 +178,11 @@ void fusedQuantizeNvQuestHad128_host(torch::Tensor& D,
   bool result = runGemm.run(D, D_sf, A, B, M, N, K, A.device(), global_scale);
 }
 
-void fusedQuantizeNvAbsMax_host(torch::Tensor& D,
-                        torch::Tensor& D_sf,
-                        torch::Tensor const& A,
-                        torch::Tensor const& B,
-                        torch::Tensor const& global_scale)
+void fusedQuantizeNvAbsMax_host(torch::stable::Tensor& D,
+                        torch::stable::Tensor& D_sf,
+                        torch::stable::Tensor const& A,
+                        torch::stable::Tensor const& B,
+                        torch::stable::Tensor const& global_scale)
 {
   int32_t M = A.numel() / 16;
   int32_t N = B.size(1);
@@ -206,11 +196,11 @@ void fusedQuantizeNvAbsMax_host(torch::Tensor& D,
   bool result = runGemm.run(D, D_sf, A, B, M, N, K, A.device(), global_scale);
 }
 
-void fusedQuantizeNvAbsMaxHad32_host(torch::Tensor& D,
-                        torch::Tensor& D_sf,
-                        torch::Tensor const& A,
-                        torch::Tensor const& B,
-                        torch::Tensor const& global_scale)
+void fusedQuantizeNvAbsMaxHad32_host(torch::stable::Tensor& D,
+                        torch::stable::Tensor& D_sf,
+                        torch::stable::Tensor const& A,
+                        torch::stable::Tensor const& B,
+                        torch::stable::Tensor const& global_scale)
 {
   int32_t M = A.numel() / 32;
   int32_t N = B.size(1);
@@ -224,11 +214,11 @@ void fusedQuantizeNvAbsMaxHad32_host(torch::Tensor& D,
   bool result = runGemm.run(D, D_sf, A, B, M, N, K, A.device(), global_scale);
 }
 
-void fusedQuantizeNvAbsMaxHad64_host(torch::Tensor& D,
-                        torch::Tensor& D_sf,
-                        torch::Tensor const& A,
-                        torch::Tensor const& B,
-                        torch::Tensor const& global_scale)
+void fusedQuantizeNvAbsMaxHad64_host(torch::stable::Tensor& D,
+                        torch::stable::Tensor& D_sf,
+                        torch::stable::Tensor const& A,
+                        torch::stable::Tensor const& B,
+                        torch::stable::Tensor const& global_scale)
 {
   int32_t M = A.numel() / 64;
   int32_t N = B.size(1);
@@ -242,11 +232,11 @@ void fusedQuantizeNvAbsMaxHad64_host(torch::Tensor& D,
   bool result = runGemm.run(D, D_sf, A, B, M, N, K, A.device(), global_scale);
 }
 
-void fusedQuantizeNvAbsMaxHad128_host(torch::Tensor& D,
-                        torch::Tensor& D_sf,
-                        torch::Tensor const& A,
-                        torch::Tensor const& B,
-                        torch::Tensor const& global_scale)
+void fusedQuantizeNvAbsMaxHad128_host(torch::stable::Tensor& D,
+                        torch::stable::Tensor& D_sf,
+                        torch::stable::Tensor const& A,
+                        torch::stable::Tensor const& B,
+                        torch::stable::Tensor const& global_scale)
 {
   int32_t M = A.numel() / 128;
   int32_t N = B.size(1);

--- a/qutlass/csrc/fused_quantize_nv_sm100.cu
+++ b/qutlass/csrc/fused_quantize_nv_sm100.cu
@@ -14,16 +14,6 @@
  * limitations under the License.
  */
 
-#include <ATen/ATen.h>
-#include <torch/types.h>
-#include <ATen/cuda/CUDAContext.h>
-#include <c10/cuda/CUDAGuard.h>
-#include <cuda_runtime.h>
-
-#ifndef QUTLASS_DISABLE_PYBIND
-#include <torch/extension.h>
-#endif
-
 #include "cutlass/cutlass.h"
 
 #include "cute/tensor.hpp"
@@ -128,11 +118,11 @@ constexpr bool IsBlockScaleSupported = FusionOp::IsBlockScaleSupported;
 using SfdOutputCfg = cutlass::detail::Sm1xxBlockScaledOutputConfig<OutputSFVectorSize>;
 using LayoutSFD = typename SfdOutputCfg::LayoutSF;
 
-typename Gemm::Arguments args_from_options_nv(torch::Tensor& D,
-                                           torch::Tensor& D_sf,
-                                           torch::Tensor const& A,
-                                           torch::Tensor const& B,
-                                           torch::Tensor const& global_scale,
+typename Gemm::Arguments args_from_options_nv(torch::stable::Tensor& D,
+                                           torch::stable::Tensor& D_sf,
+                                           torch::stable::Tensor const& A,
+                                           torch::stable::Tensor const& B,
+                                           torch::stable::Tensor const& global_scale,
                                            int32_t M, int32_t N, int32_t K)
 {
     using ElementA       = typename Gemm::ElementA;
@@ -155,30 +145,30 @@ typename Gemm::Arguments args_from_options_nv(torch::Tensor& D,
         cutlass::gemm::GemmUniversalMode::kGemm,
         {M, N, K, 1},
         {
-            static_cast<ElementA const*>(A.data_ptr()),      stride_A,
-            static_cast<ElementB const*>(B.data_ptr()),      stride_B},
+            static_cast<ElementA const*>(A.const_data_ptr()),      stride_A,
+            static_cast<ElementB const*>(B.const_data_ptr()),      stride_B},
         {
             {1.f, 0.f},
             nullptr, stride_C,
-            static_cast<ElementD*>(D.data_ptr()),       stride_D
+            static_cast<ElementD*>(D.mutable_data_ptr()),       stride_D
         }
     };
 
     if constexpr (IsBlockScaleSupported) {
-        arguments.epilogue.thread.block_scale_factor_ptr = static_cast<cutlass::float_ue4m3_t*>(D_sf.data_ptr());
-        arguments.epilogue.thread.norm_constant_ptr      = static_cast<ElementAccumulator const*>(global_scale.data_ptr());;
+        arguments.epilogue.thread.block_scale_factor_ptr = static_cast<cutlass::float_ue4m3_t*>(D_sf.mutable_data_ptr());
+        arguments.epilogue.thread.norm_constant_ptr      = static_cast<ElementAccumulator const*>(global_scale.const_data_ptr());
     }
 
     return arguments;
 }
 
-void runGemmNv(torch::Tensor& D,
-             torch::Tensor& D_sf,
-             torch::Tensor const& A,
-             torch::Tensor const& B,
-             torch::Tensor const& global_scale,
+void runGemmNv(torch::stable::Tensor& D,
+             torch::stable::Tensor& D_sf,
+             torch::stable::Tensor const& A,
+             torch::stable::Tensor const& B,
+             torch::stable::Tensor const& global_scale,
              int32_t M, int32_t N, int32_t K,
-             torch::Device device)
+             torch::stable::Device device)
 {
     Gemm gemm;
 
@@ -189,8 +179,8 @@ void runGemmNv(torch::Tensor& D,
 
     cutlass::device_memory::allocation<uint8_t> workspace(workspace_size);
 
-    const at::cuda::OptionalCUDAGuard device_guard(device_of(A));
-    cudaStream_t stream = at::cuda::getCurrentCUDAStream(device.index());
+    const torch::stable::accelerator::DeviceGuard device_guard(A.get_device_index());
+    cudaStream_t stream = get_current_cuda_stream(device.index());
 
     CUTLASS_CHECK(gemm.can_implement(arguments));
 
@@ -199,11 +189,11 @@ void runGemmNv(torch::Tensor& D,
     CUTLASS_CHECK(gemm.run(arguments, workspace.get(), stream));
 }
 
-void fusedQuantizeNvAbsMax_host_sm100(torch::Tensor& D,
-                                      torch::Tensor& D_sf,
-                                      torch::Tensor const& A,
-                                      torch::Tensor const& B,
-                                      torch::Tensor const& global_scale)
+void fusedQuantizeNvAbsMax_host_sm100(torch::stable::Tensor& D,
+                                      torch::stable::Tensor& D_sf,
+                                      torch::stable::Tensor const& A,
+                                      torch::stable::Tensor const& B,
+                                      torch::stable::Tensor const& global_scale)
 {
 #if TARGET_CUDA_ARCH == 100
     int32_t M = A.numel() / 128;
@@ -212,7 +202,7 @@ void fusedQuantizeNvAbsMax_host_sm100(torch::Tensor& D,
 
     runGemmNv(D, D_sf, A, B, global_scale, M, N, K, A.device());
 #else
-    TORCH_CHECK(false, "Unsupported CUDA arch");
+    STD_TORCH_CHECK(false, "Unsupported CUDA arch");
 #endif
 }
 

--- a/qutlass/csrc/gemm.cu
+++ b/qutlass/csrc/gemm.cu
@@ -14,16 +14,6 @@
  * limitations under the License.
  */
 
-#include <ATen/ATen.h>
-#include <torch/types.h>
-#include <ATen/cuda/CUDAContext.h>
-#include <c10/cuda/CUDAGuard.h>
-#include <cuda_runtime.h>
-
-#ifndef QUTLASS_DISABLE_PYBIND
-#include <torch/extension.h>
-#endif
-
 #include "cutlass/cutlass.h"
 #include "cutlass/gemm/collective/collective_builder.hpp"
 #include "cutlass/epilogue/collective/collective_builder.hpp"
@@ -99,12 +89,12 @@ struct FpGemm {
 
 template <typename Gemm, typename ScaleType>
 typename Gemm::Arguments args_from_options(
-                                at::Tensor& D,
-                                at::Tensor const& A,
-                                at::Tensor const& B,
-                                at::Tensor const& A_sf,
-                                at::Tensor const& B_sf,
-                                torch::Tensor const& alpha,
+                                torch::stable::Tensor& D,
+                                torch::stable::Tensor const& A,
+                                torch::stable::Tensor const& B,
+                                torch::stable::Tensor const& A_sf,
+                                torch::stable::Tensor const& B_sf,
+                                torch::stable::Tensor const& alpha,
                                 int M, int N, int K)
 {
     using ElementA       = typename Gemm::ElementA;
@@ -136,31 +126,31 @@ typename Gemm::Arguments args_from_options(
         cutlass::gemm::GemmUniversalMode::kGemm,
         {M, N, K, 1},
         {
-            static_cast<ElementA const*>(A.data_ptr()),      stride_A,
-            static_cast<ElementB const*>(B.data_ptr()),      stride_B,
-            static_cast<ElementSFA const*>(A_sf.data_ptr()), layout_SFA,
-            static_cast<ElementSFB const*>(B_sf.data_ptr()), layout_SFB},
+            static_cast<ElementA const*>(A.const_data_ptr()),      stride_A,
+            static_cast<ElementB const*>(B.const_data_ptr()),      stride_B,
+            static_cast<ElementSFA const*>(A_sf.const_data_ptr()), layout_SFA,
+            static_cast<ElementSFB const*>(B_sf.const_data_ptr()), layout_SFB},
         {
             {},
-            static_cast<ElementD const*>(D.data_ptr()), stride_D,
-            static_cast<ElementD*>(D.data_ptr()),       stride_D
+            static_cast<ElementD const*>(D.const_data_ptr()), stride_D,
+            static_cast<ElementD*>(D.mutable_data_ptr()),       stride_D
         }
     };
     auto& fusion_args = arguments.epilogue.thread;
-    fusion_args.alpha_ptr = static_cast<ElementAccumulator const*>(alpha.data_ptr());
+    fusion_args.alpha_ptr = static_cast<ElementAccumulator const*>(alpha.const_data_ptr());
 
     return arguments;
 }
 
 template <typename Gemm, typename ScaleType>
-void runGemm(at::Tensor& D,
-             at::Tensor const& A,
-             at::Tensor const& B,
-             at::Tensor const& A_sf,
-             at::Tensor const& B_sf,
-             torch::Tensor const& alpha,
+void runGemm(torch::stable::Tensor& D,
+             torch::stable::Tensor const& A,
+             torch::stable::Tensor const& B,
+             torch::stable::Tensor const& A_sf,
+             torch::stable::Tensor const& B_sf,
+             torch::stable::Tensor const& alpha,
              int M, int N, int K,
-             torch::Device device)
+             torch::stable::Device device)
 {
     Gemm gemm;
 
@@ -171,8 +161,8 @@ void runGemm(at::Tensor& D,
 
     cutlass::device_memory::allocation<uint8_t> workspace(workspace_size);
 
-    const at::cuda::OptionalCUDAGuard device_guard(device_of(A));
-    cudaStream_t stream = at::cuda::getCurrentCUDAStream(device.index());
+    const torch::stable::accelerator::DeviceGuard device_guard(A.get_device_index());
+    cudaStream_t stream = get_current_cuda_stream(device.index());
 
     CUTLASS_CHECK(gemm.can_implement(arguments));
 
@@ -181,16 +171,16 @@ void runGemm(at::Tensor& D,
     CUTLASS_CHECK(gemm.run(arguments, workspace.get(), stream));
 }
 
-void matmul_host_mxf4_bf16_tn(torch::Tensor& D,
-                              torch::Tensor const& A,
-                              torch::Tensor const& B,
-                              torch::Tensor const& A_sf,
-                              torch::Tensor const& B_sf,
-                              torch::Tensor const& alpha)
+void matmul_host_mxf4_bf16_tn(torch::stable::Tensor& D,
+                              torch::stable::Tensor const& A,
+                              torch::stable::Tensor const& B,
+                              torch::stable::Tensor const& A_sf,
+                              torch::stable::Tensor const& B_sf,
+                              torch::stable::Tensor const& alpha)
 {
-    auto const m = A.sizes()[0];
-    auto const n = B.sizes()[0];
-    auto const k = A.sizes()[1] * 2;
+    auto const m = A.size(0);
+    auto const n = B.size(0);
+    auto const k = A.size(1) * 2;
 
     using ElementA   = cutlass::mx_float4_t<cutlass::float_e2m1_t>;
     using LayoutATag = cutlass::layout::RowMajor;
@@ -253,20 +243,20 @@ void matmul_host_mxf4_bf16_tn(torch::Tensor& D,
                 >(D, A, B, A_sf, B_sf, alpha, m, n, k, A.device());
     }
 #else
-    TORCH_CHECK(false, "Unsupported CUDA arch");
+    STD_TORCH_CHECK(false, "Unsupported CUDA arch");
 #endif
 }
 
-void matmul_host_nvf4_bf16_tn(torch::Tensor& D,
-                              torch::Tensor const& A,
-                              torch::Tensor const& B,
-                              torch::Tensor const& A_sf,
-                              torch::Tensor const& B_sf,
-                              torch::Tensor const& alpha)
+void matmul_host_nvf4_bf16_tn(torch::stable::Tensor& D,
+                              torch::stable::Tensor const& A,
+                              torch::stable::Tensor const& B,
+                              torch::stable::Tensor const& A_sf,
+                              torch::stable::Tensor const& B_sf,
+                              torch::stable::Tensor const& alpha)
 {
-    auto const m = A.sizes()[0];
-    auto const n = B.sizes()[0];
-    auto const k = A.sizes()[1] * 2;
+    auto const m = A.size(0);
+    auto const n = B.size(0);
+    auto const k = A.size(1) * 2;
 
     using ElementA   = cutlass::nv_float4_t<cutlass::float_e2m1_t>;
     using LayoutATag = cutlass::layout::RowMajor;
@@ -330,21 +320,21 @@ void matmul_host_nvf4_bf16_tn(torch::Tensor& D,
                 >(D, A, B, A_sf, B_sf, alpha, m, n, k, A.device());
     }
 #else
-    TORCH_CHECK(false, "Unsupported CUDA arch");
+    STD_TORCH_CHECK(false, "Unsupported CUDA arch");
 #endif
 
 }
 
-void matmul_host_mxf8_bf16_tn(torch::Tensor& D,
-                              torch::Tensor const& A,
-                              torch::Tensor const& B,
-                              torch::Tensor const& A_sf,
-                              torch::Tensor const& B_sf,
-                              torch::Tensor const& alpha)
+void matmul_host_mxf8_bf16_tn(torch::stable::Tensor& D,
+                              torch::stable::Tensor const& A,
+                              torch::stable::Tensor const& B,
+                              torch::stable::Tensor const& A_sf,
+                              torch::stable::Tensor const& B_sf,
+                              torch::stable::Tensor const& alpha)
 {
-    auto const m = A.sizes()[0];
-    auto const n = B.sizes()[0];
-    auto const k = A.sizes()[1];
+    auto const m = A.size(0);
+    auto const n = B.size(0);
+    auto const k = A.size(1);
 
     using ElementA   = cutlass::mx_float8_t<cutlass::float_e4m3_t>;
     using LayoutATag = cutlass::layout::RowMajor;
@@ -391,20 +381,20 @@ void matmul_host_mxf8_bf16_tn(torch::Tensor& D,
                     ElementB, LayoutBTag, AlignmentB>::Gemm, cutlass::float_ue8m0_t
                 >(D, A, B, A_sf, B_sf, alpha, m, n, k, A.device());
 #else
-    TORCH_CHECK(false, "Unsupported CUDA arch");
+    STD_TORCH_CHECK(false, "Unsupported CUDA arch");
 #endif
 }
 
-void matmul_host_mxf8_bf16_nn(torch::Tensor& D,
-                              torch::Tensor const& A,
-                              torch::Tensor const& B,
-                              torch::Tensor const& A_sf,
-                              torch::Tensor const& B_sf,
-                              torch::Tensor const& alpha)
+void matmul_host_mxf8_bf16_nn(torch::stable::Tensor& D,
+                              torch::stable::Tensor const& A,
+                              torch::stable::Tensor const& B,
+                              torch::stable::Tensor const& A_sf,
+                              torch::stable::Tensor const& B_sf,
+                              torch::stable::Tensor const& alpha)
 {
-    auto const m = A.sizes()[1];
-    auto const n = B.sizes()[0];
-    auto const k = A.sizes()[0];
+    auto const m = A.size(1);
+    auto const n = B.size(0);
+    auto const k = A.size(0);
 
     using ElementA   = cutlass::mx_float8_t<cutlass::float_e4m3_t>;
     using LayoutATag = cutlass::layout::ColumnMajor;
@@ -439,6 +429,6 @@ void matmul_host_mxf8_bf16_nn(torch::Tensor& D,
                     >(D, A, B, A_sf, B_sf, alpha, m, n, k, A.device());
     }
 #else
-    TORCH_CHECK(false, "Unsupported CUDA arch");
+    STD_TORCH_CHECK(false, "Unsupported CUDA arch");
 #endif
 }

--- a/qutlass/csrc/gemm_ada.cu
+++ b/qutlass/csrc/gemm_ada.cu
@@ -14,16 +14,6 @@
  * limitations under the License.
  */
 
-#include <ATen/ATen.h>
-#include <torch/types.h>
-#include <ATen/cuda/CUDAContext.h>
-#include <c10/cuda/CUDAGuard.h>
-#include <cuda_runtime.h>
-
-#ifndef QUTLASS_DISABLE_PYBIND
-#include <torch/extension.h>
-#endif
-
 #include <stddef.h>
 
 #include <cutlass/core_io.h>
@@ -37,13 +27,13 @@
 #include <gemm.h>
 
 template <typename TileShape, typename WarpShape, int kStages>
-void qutlass_matmul_mxf4_v1(torch::Tensor const&input,
-                            torch::Tensor const&weight,
-                            torch::Tensor const&input_sf,
-                            torch::Tensor const&weight_sf,
-                            torch::Tensor &out,
-                            torch::Tensor const& alpha,
-                            torch::Device device)
+void qutlass_matmul_mxf4_v1(torch::stable::Tensor const& input,
+                            torch::stable::Tensor const& weight,
+                            torch::stable::Tensor const& input_sf,
+                            torch::stable::Tensor const& weight_sf,
+                            torch::stable::Tensor &out,
+                            torch::stable::Tensor const& alpha,
+                            torch::stable::Device device)
 {
   auto M = input.size(0);
   auto N = weight.size(0);
@@ -87,29 +77,30 @@ void qutlass_matmul_mxf4_v1(torch::Tensor const&input,
   cutlass::gemm::GemmCoord problem_size(M, N, K);
 
   cutlass::TensorRef<ElementInputA, LayoutInputA> input_ref(
-      static_cast<ElementInputA*>(input.data_ptr()),
+      static_cast<ElementInputA*>(const_cast<void*>(input.const_data_ptr())),
       LayoutInputA::packed(input_size));
 
   cutlass::TensorRef<ElementInputB, LayoutInputB> weight_ref(
-      static_cast<ElementInputB*>(weight.data_ptr()),
+      static_cast<ElementInputB*>(const_cast<void*>(weight.const_data_ptr())),
       LayoutInputB::packed(weight_size));
 
   cutlass::TensorRef<ElementOutput, LayoutOutput> out_ref(
-      static_cast<ElementOutput*>(out.data_ptr()),
+      static_cast<ElementOutput*>(out.mutable_data_ptr()),
       LayoutOutput::packed(output_size));
 
   typename Gemm::Arguments arguments{
       problem_size,
       input_ref,
-      reinterpret_cast<const cutlass::float_ue8m0_t*>(input_sf.data_ptr()),
+      reinterpret_cast<const cutlass::float_ue8m0_t*>(input_sf.const_data_ptr()),
       weight_ref,
-      reinterpret_cast<const cutlass::float_ue8m0_t*>(weight_sf.data_ptr()),
+      reinterpret_cast<const cutlass::float_ue8m0_t*>(weight_sf.const_data_ptr()),
       out_ref,
       out_ref,
       {},
       1
   };
-  arguments.epilogue.alpha_ptr = static_cast<ElementAccumulator const*>(alpha.data_ptr());
+  arguments.epilogue.alpha_ptr =
+      static_cast<ElementAccumulator const*>(alpha.const_data_ptr());
 
   Gemm gemm_op;
 
@@ -118,20 +109,20 @@ void qutlass_matmul_mxf4_v1(torch::Tensor const&input,
 
   CUTLASS_CHECK(gemm_op.can_implement(arguments));
 
-  const at::cuda::OptionalCUDAGuard device_guard(device_of(input));
-  cudaStream_t stream = at::cuda::getCurrentCUDAStream(device.index());
+  const torch::stable::accelerator::DeviceGuard device_guard(input.get_device_index());
+  cudaStream_t stream = get_current_cuda_stream(device.index());
 
   CUTLASS_CHECK(gemm_op.initialize(arguments, workspace.get(), stream));
 
   CUTLASS_CHECK(gemm_op(stream));
 }
 
-void matmul_host_ada_mxf4_bf16_tn(torch::Tensor const&input,
-                                  torch::Tensor const&weight,
-                                  torch::Tensor const&input_sf,
-                                  torch::Tensor const&weight_sf,
-                                  torch::Tensor &out,
-                                  torch::Tensor const& alpha)
+void matmul_host_ada_mxf4_bf16_tn(torch::stable::Tensor const& input,
+                                  torch::stable::Tensor const& weight,
+                                  torch::stable::Tensor const& input_sf,
+                                  torch::stable::Tensor const& weight_sf,
+                                  torch::stable::Tensor &out,
+                                  torch::stable::Tensor const& alpha)
 {
   using TileShape = typename cutlass::gemm::GemmShape<16, 16, 256>;
   using WarpShape = typename cutlass::gemm::GemmShape<16, 16, 256>;
@@ -140,6 +131,6 @@ void matmul_host_ada_mxf4_bf16_tn(torch::Tensor const&input,
 #if TARGET_CUDA_ARCH == 120
   qutlass_matmul_mxf4_v1<TileShape, WarpShape, kStages>(input, weight, input_sf, weight_sf, out, alpha, input.device());
 #else
-    TORCH_CHECK(false, "matmul_ada_mxf4_bf16_tn was optimized for sm120. For other architectures, please use matmul_mxf4_bf16_tn instead");
+    STD_TORCH_CHECK(false, "matmul_ada_mxf4_bf16_tn was optimized for sm120. For other architectures, please use matmul_mxf4_bf16_tn instead");
 #endif
 }

--- a/qutlass/csrc/include/bindings_utils.h
+++ b/qutlass/csrc/include/bindings_utils.h
@@ -1,0 +1,141 @@
+#pragma once
+
+#include <initializer_list>
+#include <iostream>
+#include <sstream>
+
+#include <torch/csrc/stable/tensor.h>
+#include <torch/headeronly/core/DeviceType.h>
+#include <torch/headeronly/util/Exception.h>
+
+namespace {
+
+using torch::stable::Tensor;
+using torch::headeronly::DeviceType;
+
+struct TensorArg {
+  const Tensor& tensor;
+  const char* name;
+  int pos;
+};
+
+inline std::ostream& operator<<(std::ostream& out, const TensorArg& t) {
+  if (t.pos == 0) {
+    out << '\'' << t.name << '\'';
+  } else {
+    out << "argument #" << t.pos << " '" << t.name << '\'';
+  }
+  return out;
+}
+
+inline const char* device_type_name(DeviceType type) {
+  switch (type) {
+    case DeviceType::CPU:
+      return "cpu";
+    case DeviceType::CUDA:
+      return "cuda";
+    case DeviceType::HIP:
+      return "hip";
+    case DeviceType::XLA:
+      return "xla";
+    case DeviceType::MPS:
+      return "mps";
+    case DeviceType::XPU:
+      return "xpu";
+    case DeviceType::Meta:
+      return "meta";
+    case DeviceType::PrivateUse1:
+      return "privateuseone";
+    default:
+      return "unknown";
+  }
+}
+
+inline void append_device_type_string(std::ostream& out, DeviceType type) {
+  out << device_type_name(type);
+}
+
+inline void append_device_string(std::ostream& out, const Tensor& t) {
+  const auto device = t.device();
+  append_device_type_string(out, device.type());
+  if (device.has_index()) {
+    out << ':' << device.index();
+  }
+}
+
+inline void check_contiguous(const char* op, const TensorArg& t) {
+  if (t.tensor.is_contiguous()) {
+    return;
+  }
+  std::ostringstream oss;
+  oss << "Expected contiguous tensor, but got non-contiguous tensor for " << t
+      << " (while checking arguments for " << op << ")";
+  STD_TORCH_CHECK(false, oss.str());
+}
+
+inline void check_all_contiguous(const char* op,
+                                 std::initializer_list<TensorArg> args) {
+  for (const auto& arg : args) {
+    check_contiguous(op, arg);
+  }
+}
+
+inline void check_device_type_cuda(const char* op,
+                                   std::initializer_list<Tensor> tensors) {
+  for (const auto& tensor : tensors) {
+    if (tensor.device().is_cuda()) {
+      continue;
+    }
+    std::ostringstream oss;
+    oss << "Expected tensor to have cuda DeviceType, but got tensor with "
+        << device_type_name(tensor.device().type())
+        << " DeviceType (while checking arguments for " << op << ")";
+    STD_TORCH_CHECK(false, oss.str());
+  }
+}
+
+inline void check_same_gpu(const char* op,
+                           const TensorArg& t1,
+                           const TensorArg& t2) {
+  const bool t1_cuda = t1.tensor.device().is_cuda();
+  const bool t2_cuda = t2.tensor.device().is_cuda();
+  if (!t1_cuda || !t2_cuda) {
+    std::ostringstream oss;
+    if (!t1_cuda) {
+      oss << "Tensor for " << t1 << " is on CPU, ";
+    }
+    if (!t2_cuda) {
+      oss << "Tensor for " << t2 << " is on CPU, ";
+    }
+    oss << "but expected " << ((t1_cuda && t2_cuda) ? "them" : "it")
+        << " to be on GPU (while checking arguments for " << op << ')';
+    STD_TORCH_CHECK(false, oss.str());
+  }
+  const int d1 = t1.tensor.get_device_index();
+  const int d2 = t2.tensor.get_device_index();
+  if (d1 == d2) {
+    return;
+  }
+  std::ostringstream oss;
+  oss << "Expected tensor for " << t1 << " to have the same device as tensor for "
+      << t2 << "; but device ";
+  append_device_string(oss, t1.tensor);
+  oss << " does not equal ";
+  append_device_string(oss, t2.tensor);
+  oss << " (while checking arguments for " << op << ")";
+  STD_TORCH_CHECK(false, oss.str());
+}
+
+inline void check_all_same_gpu(const char* op,
+                               std::initializer_list<TensorArg> args) {
+  const TensorArg* first = nullptr;
+  for (const auto& arg : args) {
+    if (first == nullptr) {
+      first = &arg;
+    } else {
+      check_same_gpu(op, *first, arg);
+    }
+  }
+}
+
+}  // namespace

--- a/qutlass/csrc/include/bindings_utils.h
+++ b/qutlass/csrc/include/bindings_utils.h
@@ -10,6 +10,9 @@
 
 namespace {
 
+// methods in here are meant to mirror some of the methods 
+// in PyTorch's aten/src/ATen/TensorUtils.cpp file
+
 using torch::stable::Tensor;
 using torch::headeronly::DeviceType;
 
@@ -21,6 +24,8 @@ struct TensorArg {
 
 inline std::ostream& operator<<(std::ostream& out, const TensorArg& t) {
   if (t.pos == 0) {
+    // 0 is distinguished; it usually indicates 'self' or the return
+    // tensor
     out << '\'' << t.name << '\'';
   } else {
     out << "argument #" << t.pos << " '" << t.name << '\'';
@@ -51,32 +56,24 @@ inline const char* device_type_name(DeviceType type) {
   }
 }
 
-inline void append_device_type_string(std::ostream& out, DeviceType type) {
-  out << device_type_name(type);
-}
-
 inline void append_device_string(std::ostream& out, const Tensor& t) {
   const auto device = t.device();
-  append_device_type_string(out, device.type());
+  out << device_type_name(device.type());
   if (device.has_index()) {
     out << ':' << device.index();
   }
 }
 
-inline void check_contiguous(const char* op, const TensorArg& t) {
-  if (t.tensor.is_contiguous()) {
-    return;
-  }
-  std::ostringstream oss;
-  oss << "Expected contiguous tensor, but got non-contiguous tensor for " << t
-      << " (while checking arguments for " << op << ")";
-  STD_TORCH_CHECK(false, oss.str());
-}
-
 inline void check_all_contiguous(const char* op,
                                  std::initializer_list<TensorArg> args) {
   for (const auto& arg : args) {
-    check_contiguous(op, arg);
+    if (arg.tensor.is_contiguous()) {
+      continue;
+    }
+    std::ostringstream oss;
+    oss << "Expected contiguous tensor, but got non-contiguous tensor for " << arg
+        << " (while checking arguments for " << op << ")";
+    STD_TORCH_CHECK(false, oss.str());
   }
 }
 
@@ -97,22 +94,22 @@ inline void check_device_type_cuda(const char* op,
 inline void check_same_gpu(const char* op,
                            const TensorArg& t1,
                            const TensorArg& t2) {
-  const bool t1_cuda = t1.tensor.device().is_cuda();
-  const bool t2_cuda = t2.tensor.device().is_cuda();
-  if (!t1_cuda || !t2_cuda) {
+  const bool t1_cpu = t1.tensor.device().is_cpu();
+  const bool t2_cpu = t2.tensor.device().is_cpu();
+  if (t1_cpu || t2_cpu) {
     std::ostringstream oss;
-    if (!t1_cuda) {
+    if (t1_cpu) {
       oss << "Tensor for " << t1 << " is on CPU, ";
     }
-    if (!t2_cuda) {
+    if (t2_cpu) {
       oss << "Tensor for " << t2 << " is on CPU, ";
     }
-    oss << "but expected " << ((t1_cuda && t2_cuda) ? "them" : "it")
+    oss << "but expected " << ((t1_cpu && t2_cpu) ? "them" : "it")
         << " to be on GPU (while checking arguments for " << op << ')';
     STD_TORCH_CHECK(false, oss.str());
   }
-  const int d1 = t1.tensor.get_device_index();
-  const int d2 = t2.tensor.get_device_index();
+  const auto d1 = t1.tensor.device();
+  const auto d2 = t2.tensor.device();
   if (d1 == d2) {
     return;
   }

--- a/qutlass/csrc/include/common.h
+++ b/qutlass/csrc/include/common.h
@@ -31,7 +31,7 @@
 /**
  * Panic wrapper for unwinding CUDA runtime errors
  */
-  #define CUDA_CHECK(status)                                          \
+#define CUDA_CHECK(status)                                            \
   {                                                                   \
     cudaError_t error = status;                                       \
     STD_TORCH_CHECK(error == cudaSuccess, cudaGetErrorString(error)); \

--- a/qutlass/csrc/include/common.h
+++ b/qutlass/csrc/include/common.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#pragma once
 #include <iostream>
 #include <stdexcept>
 #include <cstdint>
@@ -8,30 +7,42 @@
 
 #include <cuda_fp16.h>
 #include <cuda_runtime.h>
-
-#include <cstdint>
 #include <cuda.h>
+
+#include <torch/csrc/stable/tensor.h>
+#include <torch/csrc/stable/ops.h>
+#include <torch/csrc/stable/accelerator.h>
+#include <torch/csrc/inductor/aoti_torch/c/shim.h>
+#include <torch/headeronly/util/Exception.h>
+#include <torch/headeronly/util/shim_utils.h>
 
 #include "cutlass/cutlass.h"
 
 /**
  * Helper function for checking CUTLASS errors
  */
-#define CUTLASS_CHECK(status)                       \
-  {                                                 \
-    cutlass::Status error = status;                 \
-    TORCH_CHECK(error == cutlass::Status::kSuccess, \
-                cutlassGetStatusString(error));     \
+#define CUTLASS_CHECK(status)                              \
+  {                                                        \
+    cutlass::Status error = status;                        \
+    STD_TORCH_CHECK(error == cutlass::Status::kSuccess,    \
+                    cutlassGetStatusString(error));        \
   }
 
 /**
  * Panic wrapper for unwinding CUDA runtime errors
  */
-#define CUDA_CHECK(status)                                        \
-  {                                                               \
-    cudaError_t error = status;                                   \
-    TORCH_CHECK(error == cudaSuccess, cudaGetErrorString(error)); \
+  #define CUDA_CHECK(status)                                          \
+  {                                                                   \
+    cudaError_t error = status;                                       \
+    STD_TORCH_CHECK(error == cudaSuccess, cudaGetErrorString(error)); \
   }
+
+inline cudaStream_t get_current_cuda_stream(int32_t device_index) {
+  void* stream_ptr = nullptr;
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_get_current_cuda_stream(device_index, &stream_ptr));
+  return reinterpret_cast<cudaStream_t>(stream_ptr);
+}
 
 inline int get_cuda_max_shared_memory_per_block_opt_in(int const device) {
   int max_shared_mem_per_block_opt_in = 0;

--- a/qutlass/csrc/include/cutlass_extensions/epilogue/thread/linear_combination_quant.h
+++ b/qutlass/csrc/include/cutlass_extensions/epilogue/thread/linear_combination_quant.h
@@ -39,10 +39,6 @@
 */
 #pragma once
 
-#ifndef QUTLASS_DISABLE_PYBIND
-#include <torch/extension.h>
-#endif
-
 #include "cutlass/array.h"
 #include "cutlass/cutlass.h"
 #include "cutlass/epilogue/thread/linear_combination_params.h"

--- a/qutlass/csrc/include/fused_quantize_host.h
+++ b/qutlass/csrc/include/fused_quantize_host.h
@@ -19,100 +19,100 @@
 
 namespace QUTLASS {
 
-void fusedQuantizeMxQuest_host(torch::Tensor&       D,
-                               torch::Tensor&       D_sf,
-                               torch::Tensor const& A,
-                               torch::Tensor const& B);
+void fusedQuantizeMxQuest_host(torch::stable::Tensor&       D,
+                               torch::stable::Tensor&       D_sf,
+                               torch::stable::Tensor const& A,
+                               torch::stable::Tensor const& B);
 
-void fusedQuantizeMxQuestWithMask_host(torch::Tensor&       D,
-                                       torch::Tensor&       D_sf,
-                                       torch::Tensor&       D_mask,
-                                       torch::Tensor const& A,
-                                       torch::Tensor const& B);
+void fusedQuantizeMxQuestWithMask_host(torch::stable::Tensor&       D,
+                                       torch::stable::Tensor&       D_sf,
+                                       torch::stable::Tensor&       D_mask,
+                                       torch::stable::Tensor const& A,
+                                       torch::stable::Tensor const& B);
 
-void fusedQuantizeMxAbsMax_host(torch::Tensor&       D,
-                                torch::Tensor&       D_sf,
-                                torch::Tensor const& A,
-                                torch::Tensor const& B);
+void fusedQuantizeMxAbsMax_host(torch::stable::Tensor&       D,
+                                torch::stable::Tensor&       D_sf,
+                                torch::stable::Tensor const& A,
+                                torch::stable::Tensor const& B);
 
-void fusedQuantizeMxQuestHad64_host(torch::Tensor&       D,
-                                    torch::Tensor&       D_sf,
-                                    torch::Tensor const& A,
-                                    torch::Tensor const& B);
+void fusedQuantizeMxQuestHad64_host(torch::stable::Tensor&       D,
+                                    torch::stable::Tensor&       D_sf,
+                                    torch::stable::Tensor const& A,
+                                    torch::stable::Tensor const& B);
 
-void fusedQuantizeMxAbsMaxHad64_host(torch::Tensor&       D,
-                                     torch::Tensor&       D_sf,
-                                     torch::Tensor const& A,
-                                     torch::Tensor const& B);
+void fusedQuantizeMxAbsMaxHad64_host(torch::stable::Tensor&       D,
+                                     torch::stable::Tensor&       D_sf,
+                                     torch::stable::Tensor const& A,
+                                     torch::stable::Tensor const& B);
 
-void fusedQuantizeMxQuestHad128_host(torch::Tensor&       D,
-                                     torch::Tensor&       D_sf,
-                                     torch::Tensor const& A,
-                                     torch::Tensor const& B);
+void fusedQuantizeMxQuestHad128_host(torch::stable::Tensor&       D,
+                                     torch::stable::Tensor&       D_sf,
+                                     torch::stable::Tensor const& A,
+                                     torch::stable::Tensor const& B);
 
-void fusedQuantizeMxAbsMaxHad128_host(torch::Tensor&       D,
-                                      torch::Tensor&       D_sf,
-                                      torch::Tensor const& A,
-                                      torch::Tensor const& B);
+void fusedQuantizeMxAbsMaxHad128_host(torch::stable::Tensor&       D,
+                                      torch::stable::Tensor&       D_sf,
+                                      torch::stable::Tensor const& A,
+                                      torch::stable::Tensor const& B);
 
-void fusedQuantizeNvQuest_host(torch::Tensor&       D,
-                               torch::Tensor&       D_sf,
-                               torch::Tensor const& A,
-                               torch::Tensor const& B,
-                               torch::Tensor const& global_scale);
+void fusedQuantizeNvQuest_host(torch::stable::Tensor&       D,
+                               torch::stable::Tensor&       D_sf,
+                               torch::stable::Tensor const& A,
+                               torch::stable::Tensor const& B,
+                               torch::stable::Tensor const& global_scale);
 
-void fusedQuantizeNvQuestHad32_host(torch::Tensor&       D,
-                                    torch::Tensor&       D_sf,
-                                    torch::Tensor const& A,
-                                    torch::Tensor const& B,
-                                    torch::Tensor const& global_scale);
+void fusedQuantizeNvQuestHad32_host(torch::stable::Tensor&       D,
+                                    torch::stable::Tensor&       D_sf,
+                                    torch::stable::Tensor const& A,
+                                    torch::stable::Tensor const& B,
+                                    torch::stable::Tensor const& global_scale);
 
-void fusedQuantizeNvQuestHad64_host(torch::Tensor&       D,
-                                    torch::Tensor&       D_sf,
-                                    torch::Tensor const& A,
-                                    torch::Tensor const& B,
-                                    torch::Tensor const& global_scale);
+void fusedQuantizeNvQuestHad64_host(torch::stable::Tensor&       D,
+                                    torch::stable::Tensor&       D_sf,
+                                    torch::stable::Tensor const& A,
+                                    torch::stable::Tensor const& B,
+                                    torch::stable::Tensor const& global_scale);
 
-void fusedQuantizeNvQuestHad128_host(torch::Tensor&       D,
-                                     torch::Tensor&       D_sf,
-                                     torch::Tensor const& A,
-                                     torch::Tensor const& B,
-                                     torch::Tensor const& global_scale);
+void fusedQuantizeNvQuestHad128_host(torch::stable::Tensor&       D,
+                                     torch::stable::Tensor&       D_sf,
+                                     torch::stable::Tensor const& A,
+                                     torch::stable::Tensor const& B,
+                                     torch::stable::Tensor const& global_scale);
 
-void fusedQuantizeNvAbsMax_host(torch::Tensor&       D,
-                                torch::Tensor&       D_sf,
-                                torch::Tensor const& A,
-                                torch::Tensor const& B,
-                                torch::Tensor const& global_scale);
+void fusedQuantizeNvAbsMax_host(torch::stable::Tensor&       D,
+                                torch::stable::Tensor&       D_sf,
+                                torch::stable::Tensor const& A,
+                                torch::stable::Tensor const& B,
+                                torch::stable::Tensor const& global_scale);
 
-void fusedQuantizeNvAbsMaxHad32_host(torch::Tensor&       D,
-                                     torch::Tensor&       D_sf,
-                                     torch::Tensor const& A,
-                                     torch::Tensor const& B,
-                                     torch::Tensor const& global_scale);
+void fusedQuantizeNvAbsMaxHad32_host(torch::stable::Tensor&       D,
+                                     torch::stable::Tensor&       D_sf,
+                                     torch::stable::Tensor const& A,
+                                     torch::stable::Tensor const& B,
+                                     torch::stable::Tensor const& global_scale);
 
-void fusedQuantizeNvAbsMaxHad64_host(torch::Tensor&       D,
-                                     torch::Tensor&       D_sf,
-                                     torch::Tensor const& A,
-                                     torch::Tensor const& B,
-                                     torch::Tensor const& global_scale);
+void fusedQuantizeNvAbsMaxHad64_host(torch::stable::Tensor&       D,
+                                     torch::stable::Tensor&       D_sf,
+                                     torch::stable::Tensor const& A,
+                                     torch::stable::Tensor const& B,
+                                     torch::stable::Tensor const& global_scale);
 
-void fusedQuantizeNvAbsMaxHad128_host(torch::Tensor&       D,
-                                      torch::Tensor&       D_sf,
-                                      torch::Tensor const& A,
-                                      torch::Tensor const& B,
-                                      torch::Tensor const& global_scale);
+void fusedQuantizeNvAbsMaxHad128_host(torch::stable::Tensor&       D,
+                                      torch::stable::Tensor&       D_sf,
+                                      torch::stable::Tensor const& A,
+                                      torch::stable::Tensor const& B,
+                                      torch::stable::Tensor const& global_scale);
 
-void fusedQuantizeMxAbsMax_host_sm100(torch::Tensor&       D,
-                                      torch::Tensor&       D_sf,
-                                      torch::Tensor const& A,
-                                      torch::Tensor const& B,
-                                      torch::Tensor const& global_scale);
+void fusedQuantizeMxAbsMax_host_sm100(torch::stable::Tensor&       D,
+                                      torch::stable::Tensor&       D_sf,
+                                      torch::stable::Tensor const& A,
+                                      torch::stable::Tensor const& B,
+                                      torch::stable::Tensor const& global_scale);
 
-void fusedQuantizeNvAbsMax_host_sm100(torch::Tensor&       D,
-                                      torch::Tensor&       D_sf,
-                                      torch::Tensor const& A,
-                                      torch::Tensor const& B,
-                                      torch::Tensor const& global_scale);
+void fusedQuantizeNvAbsMax_host_sm100(torch::stable::Tensor&       D,
+                                      torch::stable::Tensor&       D_sf,
+                                      torch::stable::Tensor const& A,
+                                      torch::stable::Tensor const& B,
+                                      torch::stable::Tensor const& global_scale);
 
 }  // namespace QUTLASS

--- a/qutlass/csrc/include/gemm.h
+++ b/qutlass/csrc/include/gemm.h
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+
 #pragma once
 #include <common.h>
 

--- a/qutlass/csrc/include/gemm.h
+++ b/qutlass/csrc/include/gemm.h
@@ -14,41 +14,40 @@
  * limitations under the License.
  */
 
-
 #pragma once
 #include <common.h>
 
-void matmul_host_mxf4_bf16_tn(torch::Tensor& D,
-                              torch::Tensor const& A,
-                              torch::Tensor const& B,
-                              torch::Tensor const& A_sf,
-                              torch::Tensor const& B_sf,
-                              torch::Tensor const& alpha);
+void matmul_host_mxf4_bf16_tn(torch::stable::Tensor& D,
+                              torch::stable::Tensor const& A,
+                              torch::stable::Tensor const& B,
+                              torch::stable::Tensor const& A_sf,
+                              torch::stable::Tensor const& B_sf,
+                              torch::stable::Tensor const& alpha);
 
-void matmul_host_ada_mxf4_bf16_tn(torch::Tensor const& input,
-                                  torch::Tensor const& weight,
-                                  torch::Tensor const& input_sf,
-                                  torch::Tensor const& weight_sf,
-                                  torch::Tensor &out,
-                                  torch::Tensor const& alpha);
+void matmul_host_ada_mxf4_bf16_tn(torch::stable::Tensor const& input,
+                                  torch::stable::Tensor const& weight,
+                                  torch::stable::Tensor const& input_sf,
+                                  torch::stable::Tensor const& weight_sf,
+                                  torch::stable::Tensor &out,
+                                  torch::stable::Tensor const& alpha);
 
-void matmul_host_nvf4_bf16_tn(torch::Tensor& D,
-                              torch::Tensor const& A,
-                              torch::Tensor const& B,
-                              torch::Tensor const& A_sf,
-                              torch::Tensor const& B_sf,
-                              torch::Tensor const& alpha);
+void matmul_host_nvf4_bf16_tn(torch::stable::Tensor& D,
+                              torch::stable::Tensor const& A,
+                              torch::stable::Tensor const& B,
+                              torch::stable::Tensor const& A_sf,
+                              torch::stable::Tensor const& B_sf,
+                              torch::stable::Tensor const& alpha);
 
-void matmul_host_mxf8_bf16_tn(torch::Tensor& D,
-                              torch::Tensor const& A,
-                              torch::Tensor const& B,
-                              torch::Tensor const& A_sf,
-                              torch::Tensor const& B_sf,
-                              torch::Tensor const& alpha);
+void matmul_host_mxf8_bf16_tn(torch::stable::Tensor& D,
+                              torch::stable::Tensor const& A,
+                              torch::stable::Tensor const& B,
+                              torch::stable::Tensor const& A_sf,
+                              torch::stable::Tensor const& B_sf,
+                              torch::stable::Tensor const& alpha);
 
-void matmul_host_mxf8_bf16_nn(torch::Tensor& D,
-                              torch::Tensor const& A,
-                              torch::Tensor const& B,
-                              torch::Tensor const& A_sf,
-                              torch::Tensor const& B_sf,
-                              torch::Tensor const& alpha);
+void matmul_host_mxf8_bf16_nn(torch::stable::Tensor& D,
+                              torch::stable::Tensor const& A,
+                              torch::stable::Tensor const& B,
+                              torch::stable::Tensor const& A_sf,
+                              torch::stable::Tensor const& B_sf,
+                              torch::stable::Tensor const& alpha);


### PR DESCRIPTION
This PR is to continue the libtorch stable ABI migration (see https://github.com/vllm-project/vllm/issues/26946) for vLLM.

Migrates the qutlass kernels used by vLLM from unstable libtorch C++ APIs to PyTorch’s stable ABI (torch::stable::, STABLE_TORCH_LIBRARY_, AOTI shims). This enables qutlass to ship as an abi3 extension (_qutlass_C.so) alongside vLLM’s other stable targets (e.g. _C_stable_libtorch), so the extension can be built against a narrower libtorch surface and remain compatible across PyTorch minor versions.

Migration progress using the Audit Python extension [torch-abi-audit](https://pypi.org/project/torch-abi-audit/):
```
 -- extensions --
    [STABLE  ] [abi3-ok               ] _C_stable_libtorch.abi3.so  (stable_shim=88, unstable=0)
    [UNSTABLE] [abi3-ok               ] _flashmla_C.abi3.so  (stable_shim=0, unstable=72)
    [UNSTABLE] [abi3-ok               ] _flashmla_extension_C.abi3.so  (stable_shim=0, unstable=68)
    [STABLE  ] [abi3-ok               ] _moe_C_stable_libtorch.abi3.so  (stable_shim=72, unstable=0)
--> [STABLE  ] [abi3-ok               ] _qutlass_C.abi3.so  (stable_shim=60, unstable=0)
    [NO-TORCH] [abi3-ok               ] cumem_allocator.abi3.so
    [NO-TORCH] [abi3-ok               ] spinloop.abi3.so
    [UNSTABLE] [uses-private-api      ] third_party/deep_gemm/_C.cpython-312-x86_64-linux-gnu.so  (stable_shim=0, unstable=57)
    [UNSTABLE] [abi3-ok               ] vllm_flash_attn/_vllm_fa2_C.abi3.so  (stable_shim=0, unstable=84)
    [UNSTABLE] [abi3-ok               ] vllm_flash_attn/_vllm_fa3_C.abi3.so  (stable_shim=0, unstable=80)
```

I have not gained access to Blackwell GPUs yet, so I have not been able to run unit test locally to test the migration, I have only tested that the build work and is stable. I opened the vLLM PR https://github.com/vllm-project/vllm/pull/47879 to test the changes against the vLLM CI. 


cc @Harry-Chen @janeyx99 @LopezCastroRoberto

Note @LopezCastroRoberto, this migrated the kernels used by vLLM to the torch Stable ABI, but I think there are more that are still unstable. If you would like me to do a full migration, I can follow up this PR with one that migrates the rest of the kernels. 